### PR TITLE
fix copyright

### DIFF
--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -12,13 +12,9 @@ var respecConfig = {
       // if you wish the publication date to be other than today, set this
       // publishDate:  "2014-01-27",
 
-      // new ability to override the copyright completely
-      overrideCopyright:  "<p class='copyright'>Initial Author of this Specification was Ian Hickson, Google Inc., with the following copyright statement:<br /> &#169; Copyright 2004-2011 Apple Computer, Inc., Mozilla Foundation, and Opera Software ASA. You are granted a license to use, reproduce and create derivative works of this document.</p> <p class='copyright'>All subsequent changes since 26 July 2011 done by the W3C WebRTC Working Group are under the following <a href='http://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>Copyright</a>:<br />&#169; 2011-2012 <a href='http://www.w3.org/'><acronym title='World Wide Web Consortium'>W3C</acronym></a><sup>&#174;</sup> (<a href='http://www.csail.mit.edu/'><acronym title='Massachusetts Institute of Technology'>MIT</acronym></a>, <a href='http://www.ercim.eu/'><acronym title='European Research Consortium for Informatics and Mathematics'>ERCIM</acronym></a>, <a href='http://www.keio.ac.jp/'>Keio</a>, <a href='http://ev.buaa.edu.cn/'>Beihang<\/a>), All Rights Reserved. <a href='http://www.w3.org/Consortium/Legal/copyright-documents'>Document use</a>  rules apply.</p> <p class='copyright'>For the entire publication on the W3C site the <a href='http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer'>liability</a> and <a href='http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks'>trademark</a> rules apply.</p>",
-
-
       // if the specification's copyright date is a range of years, specify
       // the start date here:
-      // copyrightStart: "2005",
+      copyrightStart: "2014",
 
       // if there is a previously published draft, uncomment this and set its YYYY-MM-DD
       // prevED: "http://dev.w3.org/2011/webrtc/editor/archives/20140321/webrtc.html",


### PR DESCRIPTION
This piece doesn't need the special WHATWG copyright statement, since it was developed well after the work was derived from the WHATWG original document.
