### PR TITLE
Keeping getStats in core spec and changing enums to strings

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -77,8 +77,9 @@
       <p>
         The concepts <dfn><a
         href="http://dev.w3.org/html5/spec/webappapis.html#queue-a-task">queue
-        a task</a></dfn>, and <dfn><a href="http://dev.w3.org/html5/spec/webappapis.html#fire-a-simple-event">fires a
-        simple event</a></dfn> are defined in [[!HTML5]].
+        a task</a></dfn>, and 
+        <dfn><a href="http://dev.w3.org/html5/spec/webappapis.html#fire-a-simple-event">fires
+        a simple event</a></dfn> are defined in [[!HTML5]].
       </p>
 
       <p>The terms <dfn>event</dfn>, <dfn><a
@@ -137,17 +138,11 @@
 
             <p>When the <dfn id=
             "dom-peerconnection-getstats"><code>getStats()</code></dfn> method is
-            invoked, the user agent MUST queue a task to run the following
-            steps:</p>
+            invoked, the user agent <em class="rfc2119" title="MUST">MUST</em> 
+            queue a task to run the following steps:</p>
 
             <ol>
-              <li>
-                <p>If the <code><a>RTCPeerConnection</a></code> object's <a href=
-                "#dom-peerconnection-signaling-state"><code>RTCPeerConnection</code>
-                signalingState</a> is <code>closed</code>, throw an
-                <code>InvalidStateError</code> exception.</p>
-              </li>
-
+              
               <li>
                 <p>Return, but continue the following steps in the
                 background.</p>
@@ -159,14 +154,23 @@
 
               <li>
                 <p>If <var>selectorArg</var> is an invalid <a href=
-                "#stats-selector">selector</a>, the user agent MUST queue a task
+                "#stats-selector">selector</a>, the user agent 
+                <em class="rfc2119" title="MUST">MUST</em> queue a task
                 to invoke the failure callback (the method's third argument).</p>
               </li>
 
               <li>
+                
                 <p>Start gathering the stats indicated by <var>selectorArg</var>.
-                In case <var>selectorArg</var> is null, stats MUST be gathered
-                for the whole <code><a>RTCPeerConnection</a></code> object.</p>
+                In case <var>selectorArg</var> is null, stats 
+                <em class="rfc2119" title="MUST">MUST</em> be gathered for
+                the whole <code><a>RTCPeerConnection</a></code> object. If the
+                <code><a>RTCPeerConnection</a></code> object's 
+                <a href="http://www.w3.org/TR/webrtc/#dom-peerconnection-signaling-state">signalingState</a> is
+                <code>closed</code>, stats should reflect the state at or near the
+                time that <a href="http://www.w3.org/TR/webrtc/#dom-peerconnection-signaling-state">signalingState</a>
+                transitioned to <code>closed</code>.
+                </p>
               </li>
 
               <li>
@@ -235,7 +239,7 @@
       <h2>RTCStats Dictionary</h2>
       <p>
         An <code><dfn>RTCStats</dfn></code> dictionary represents the stats gathered by
-        inspecting a specific object relevant to a <dfn>selector</dfn>. The
+        inspecting a specific object relevant to a <code>selector</code>. The
         <code>RTCStats</code> dictionary is a base type that specifies a set
         of default attributes, such as <a>timestamp</a> and <a>type</a>.
         Specific stats are added by extending the <code>RTCStats</code> dictionary.

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -100,28 +100,138 @@
 
     <!-- vs: does getStats() move here? -->
     <section>
-      <h2>Statistics Model</h2>
+      <h2 id="sec.stats-model">Statistics Model</h2>
+      <p>
+        The browser maintains a set of statistics referenced by a
+        <dfn id="stats-selector">selector</dfn>. The selector may,
+        for example, be a <code>MediaStreamTrack</code>. For a track to be
+        a valid selector, it <em class="rfc2119" title="MUST">MUST</em> be
+        a member of a <code>MediaStream</code> that is sent or received by the
+        <code>RTCPeerConnection</code> object on which the statistics
+        were requested.
+      </p>
 
-        <p>
-          The browser maintains a set of statistics referenced by a
-          <code>selector</code>. The selector may, for example, be a
-          <code>MediaStreamTrack</code>. For a track to be a valid selector,
-          it <em class="rfc2119" title="MUST">MUST</em> be a member of a
-          <code>MediaStream</code> that is sent or received by the
-          <code>RTCPeerConnection</code> object on which
-          the statistics were requested.
+      <div class="note">
+        Evaluate the need for other selectors than MediaStreamTrack.
+      </div>
 
-          The <dfn>getStats()</dfn> method is defined in [[!WEBRTC]] and the
-          browser emits (in the JavaScript) a set of metrics that it
-          believes are relevant to the selector.
-        </p>
+      <p>The statistics returned are designed in such a way that repeated
+      queries can be linked by the <code><a>RTCStats</a></code> <a href=
+      "#dom-rtcstats-id">id</a> dictionary member. Thus, a Web application can
+      make measurements over a given time period by requesting measurements at
+      the beginning and end of that period.</p>
 
+      <section>
+        <h3>RTCPeerConnection Interface Extensions</h3>
+
+        <p>The Statistics API extends the <code><a>RTCPeerConnection</a></code>
+        interface as described below.</p>
+
+        <dl class="idl" title="partial interface RTCPeerConnection">
+          <dt>void getStats(MediaStreamTrack? selector, RTCStatsCallback
+          successCallback, RTCPeerConnectionErrorCallback failureCallback)</dt>
+
+          <dd>
+            <p>Gathers stats for the given <a href="#stats-selector">selector</a>
+            and reports the result asynchronously.</p>
+
+            <p>When the <dfn id=
+            "dom-peerconnection-getstats"><code>getStats()</code></dfn> method is
+            invoked, the user agent MUST queue a task to run the following
+            steps:</p>
+
+            <ol>
+              <li>
+                <p>If the <code><a>RTCPeerConnection</a></code> object's <a href=
+                "#dom-peerconnection-signaling-state"><code>RTCPeerConnection</code>
+                signalingState</a> is <code>closed</code>, throw an
+                <code>InvalidStateError</code> exception.</p>
+              </li>
+
+              <li>
+                <p>Return, but continue the following steps in the
+                background.</p>
+              </li>
+
+              <li>
+                <p>Let <var>selectorArg</var> be the methods first argument.</p>
+              </li>
+
+              <li>
+                <p>If <var>selectorArg</var> is an invalid <a href=
+                "#stats-selector">selector</a>, the user agent MUST queue a task
+                to invoke the failure callback (the method's third argument).</p>
+              </li>
+
+              <li>
+                <p>Start gathering the stats indicated by <var>selectorArg</var>.
+                In case <var>selectorArg</var> is null, stats MUST be gathered
+                for the whole <code><a>RTCPeerConnection</a></code> object.</p>
+              </li>
+
+              <li>
+                <p>When the relevant stats have been gathered, queue a task to
+                invoke the success callback (the method's second argument) with a
+                new <code><a>RTCStatsReport</a></code> object, representing the
+                gathered stats, as its argument.</p>
+              </li>
+            </ol>
+          </dd>
+        </dl>
       </section>
 
+      <section>
+        <h3>RTCStatsCallback</h3>
+
+        <dl class="idl" title="callback RTCStatsCallback = void">
+          <dt>RTCStatsReport report</dt>
+
+          <dd>
+            <p>A <code><a>RTCStatsReport</a></code> representing the gathered
+            stats.</p>
+          </dd>
+        </dl>
+      </section>
+
+      <section>
+        <h3>RTCStatsReport Object</h3>
+
+        <p>The <code><a href="#dom-peerconnection-getstats">getStats()</a></code>
+        method delivers a successful result in the form of a
+        <code><a>RTCStatsReport</a></code> object. A
+        <code><a>RTCStatsReport</a></code> object represents a map between
+        strings, identifying the inspected objects (<a href=
+        "#dom-rtcstats-id">RTCStats.id</a>), and their corresponding
+        <code><a>RTCStats</a></code> objects.</p>
+
+        <p>An <code><a>RTCStatsReport</a></code> may be composed of several
+        <code><a>RTCStats</a></code> objects, each reporting stats for one
+        underlying object that the implementation thinks is relevant for the
+        <a href="#stats-selector">selector</a>. One achieves the total for the
+        <a href="#stats-selector">selector</a> by summing over all the stats of a
+        certain type; for instance, if a <code>MediaStreamTrack</code> is carried
+        by multiple SSRCs over the network, the
+        <code><a>RTCStatsReport</a></code> may contain one <code>RTCStats</code>
+        object per SSRC (which can be distinguished by the value of the "ssrc"
+        stats attribute).</p>
+
+        <dl class="idl" title="interface RTCStatsReport">
+          <dt>getter RTCStats (DOMString id)</dt>
+
+          <dd>
+            <p>Getter to retrieve the <code><a>RTCStats</a></code> objects that
+            this stats report is composed of.</p>
+
+            <p>The set of supported property names [[!WEBIDL]] is defined as the
+            ids of all the <code><a>RTCStats</a></code> objects that has been
+            generated for this stats report. The order of the property names is
+            left to the user agent.</p>
+          </dd>
+        </dl>
+      </section>
     </section>
 
     <section id="rtctats-dict*">
-
       <h2>RTCStats Dictionary</h2>
       <p>
         An <code><dfn>RTCStats</dfn></code> dictionary represents the stats gathered by
@@ -597,6 +707,59 @@ stats [
 
     </section>
 
+
+
+    <section>
+      <h3>Example</h3>
+
+      <p>Consider the case where the user is experiencing bad sound and the
+      application wants to determine if the cause of it is packet loss. The
+      following example code might be used:</p>
+      <pre class="example highlight" xml:space="preserve">
+var baselineReport, currentReport;
+var selector = pc.getRemoteStreams()[0].getAudioTracks()[0];
+
+pc.getStats(selector, function (report) {
+    baselineReport = report;
+}, logError);
+
+// ... wait a bit
+setTimeout(function () {
+    pc.getStats(selector, function (report) {
+        currentReport = report;
+        processStats();
+    }, logError);
+}, aBit);
+
+function processStats() {
+    // compare the elements from the current report with the baseline
+    for (var i in currentReport) {
+        var now = currentReport[i];
+        if (now.type != "outbund-rtp")
+            continue;
+
+        // get the corresponding stats from the baseline report
+        base = baselineReport[now.id];
+
+        if (base) {
+            remoteNow = currentReport[now.remoteId];
+            remoteBase = baselineReport[base.remoteId];
+
+            var packetsSent = now.packetsSent - base.packetsSent;
+            var packetsReceived = remoteNow.packetsReceived - remoteBase.packetsReceived;
+
+            // if fractionLost is &gt; 0.3, we have probably found the culprit
+            var fractionLost = (packetsSent - packetsReceived) / packetsSent;
+        }
+    }
+}
+
+function logError(error) {
+    log(error.name + ": " + error.message);
+}
+</pre>
+    </section>
+
     <section>
       <h3>Security Considerations</h3>
       <p>
@@ -611,16 +774,18 @@ stats [
       <h2>Change Log</h2>
 
       <p>This section will be removed before publication.</p>
-      <!-- <section id="since-01-Sept-2014*">
-        <h3>Changes since 1 September 2014</h3>
+      <section id="since-30-Sept-2014*">
+        <h3>Changes since 30 September 2014</h3>
         <ol>
-          <li>Created this document.</li>
-        </ol> -->
+          <li>Moved getStats() from webrtc-pc to this document.</li>
+        </ol>
     </section>
 
     <section class='appendix'>
       <h2>Acknowledgements</h2>
       <p>
+        The editors wish to thank the Working Group chairs, Stefan Håkansson,
+        and Team Contact, Dominique Hazaël-Massieux, for their support.
         The editors would like to thank
           [names]
         for their contributions to this specification.

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -99,222 +99,69 @@
       </p>
     </section>
 
-    <!-- vs: does getStats() move here? -->
-    <section>
-      <h2 id="sec.stats-model">Statistics Model</h2>
-      <p>
-        The browser maintains a set of statistics referenced by a
-        <dfn id="stats-selector">selector</dfn>. The selector may,
-        for example, be a <code>MediaStreamTrack</code>. For a track to be
-        a valid selector, it <em class="rfc2119" title="MUST">MUST</em> be
-        a member of a <code>MediaStream</code> that is sent or received by the
-        <code>RTCPeerConnection</code> object on which the statistics
-        were requested.
-      </p>
+    <!-- VS: getStats() remains in base spec! -->
 
+    <section id="rtctatstype-*">
+      <h2>RTCStatsType</h2>
+
+      <code>RTCStatsType</code> object is initialized to the name of the dictionary that
+      the <code>RTCStats</code> represents.
+      
       <div class="note">
-        Evaluate the need for other selectors than MediaStreamTrack.
+        OPEN ISSUE: Need to define an IANA registry for the RTCStatsType and populate
+        it with the following set as baseline. 
       </div>
 
-      <p>The statistics returned are designed in such a way that repeated
-      queries can be linked by the <code><a>RTCStats</a></code> <a href=
-      "#dom-rtcstats-id">id</a> dictionary member. Thus, a Web application can
-      make measurements over a given time period by requesting measurements at
-      the beginning and end of that period.</p>
+      <section id="rtcstatstype-str*">
+        <h3>RTCStatsType DOMString</h3>
 
-      <section>
-        <h3>RTCPeerConnection Interface Extensions</h3>
-
-        <p>The Statistics API extends the <code><a>RTCPeerConnection</a></code>
-        interface as described below.</p>
-
-        <dl class="idl" title="partial interface RTCPeerConnection">
-          <dt>void getStats(MediaStreamTrack? selector, RTCStatsCallback
-          successCallback, RTCPeerConnectionErrorCallback failureCallback)</dt>
-
-          <dd>
-            <p>Gathers stats for the given <a href="#stats-selector">selector</a>
-            and reports the result asynchronously.</p>
-
-            <p>When the <dfn id=
-            "dom-peerconnection-getstats"><code>getStats()</code></dfn> method is
-            invoked, the user agent <em class="rfc2119" title="MUST">MUST</em> 
-            queue a task to run the following steps:</p>
-
-            <ol>
-              
-              <li>
-                <p>Return, but continue the following steps in the
-                background.</p>
-              </li>
-
-              <li>
-                <p>Let <var>selectorArg</var> be the methods first argument.</p>
-              </li>
-
-              <li>
-                <p>If <var>selectorArg</var> is an invalid <a href=
-                "#stats-selector">selector</a>, the user agent 
-                <em class="rfc2119" title="MUST">MUST</em> queue a task
-                to invoke the failure callback (the method's third argument).</p>
-              </li>
-
-              <li>
-                
-                <p>Start gathering the stats indicated by <var>selectorArg</var>.
-                In case <var>selectorArg</var> is null, stats 
-                <em class="rfc2119" title="MUST">MUST</em> be gathered for
-                the whole <code><a>RTCPeerConnection</a></code> object. If the
-                <code><a>RTCPeerConnection</a></code> object's 
-                <a href="http://www.w3.org/TR/webrtc/#dom-peerconnection-signaling-state">signalingState</a> is
-                <code>closed</code>, stats should reflect the state at or near the
-                time that <a href="http://www.w3.org/TR/webrtc/#dom-peerconnection-signaling-state">signalingState</a>
-                transitioned to <code>closed</code>.
-                </p>
-              </li>
-
-              <li>
-                <p>When the relevant stats have been gathered, queue a task to
-                invoke the success callback (the method's second argument) with a
-                new <code><a>RTCStatsReport</a></code> object, representing the
-                gathered stats, as its argument.</p>
-              </li>
-            </ol>
-          </dd>
-        </dl>
-      </section>
-
-      <section>
-        <h3>RTCStatsCallback</h3>
-
-        <dl class="idl" title="callback RTCStatsCallback = void">
-          <dt>RTCStatsReport report</dt>
-
-          <dd>
-            <p>A <code><a>RTCStatsReport</a></code> representing the gathered
-            stats.</p>
-          </dd>
-        </dl>
-      </section>
-
-      <section>
-        <h3>RTCStatsReport Object</h3>
-
-        <p>The <code><a href="#dom-peerconnection-getstats">getStats()</a></code>
-        method delivers a successful result in the form of a
-        <code><a>RTCStatsReport</a></code> object. A
-        <code><a>RTCStatsReport</a></code> object represents a map between
-        strings, identifying the inspected objects (<a href=
-        "#dom-rtcstats-id">RTCStats.id</a>), and their corresponding
-        <code><a>RTCStats</a></code> objects.</p>
-
-        <p>An <code><a>RTCStatsReport</a></code> may be composed of several
-        <code><a>RTCStats</a></code> objects, each reporting stats for one
-        underlying object that the implementation thinks is relevant for the
-        <a href="#stats-selector">selector</a>. One achieves the total for the
-        <a href="#stats-selector">selector</a> by summing over all the stats of a
-        certain type; for instance, if a <code>MediaStreamTrack</code> is carried
-        by multiple SSRCs over the network, the
-        <code><a>RTCStatsReport</a></code> may contain one <code>RTCStats</code>
-        object per SSRC (which can be distinguished by the value of the "ssrc"
-        stats attribute).</p>
-
-        <dl class="idl" title="interface RTCStatsReport">
-          <dt>getter RTCStats (DOMString id)</dt>
-
-          <dd>
-            <p>Getter to retrieve the <code><a>RTCStats</a></code> objects that
-            this stats report is composed of.</p>
-
-            <p>The set of supported property names [[!WEBIDL]] is defined as the
-            ids of all the <code><a>RTCStats</a></code> objects that has been
-            generated for this stats report. The order of the property names is
-            left to the user agent.</p>
-          </dd>
-        </dl>
-      </section>
-    </section>
-
-    <section id="rtctats-dict*">
-      <h2>RTCStats Dictionary</h2>
-      <p>
-        An <code><dfn>RTCStats</dfn></code> dictionary represents the stats gathered by
-        inspecting a specific object relevant to a <code>selector</code>. The
-        <code>RTCStats</code> dictionary is a base type that specifies a set
-        of default attributes, such as <a>timestamp</a> and <a>type</a>.
-        Specific stats are added by extending the <code>RTCStats</code> dictionary.
-      </p>
-
-      <dl class="idl" title="dictionary RTCStats">
-        <dt>DOMHiResTimeStamp timestamp</dt>
-        <dd><p>The <dfn><code>timestamp</code></dfn>, of type <code>DOMHiResTimeStamp</code>
-          [[HIGHRES-TIME]], associated with this object. The time is relative
-          to the UNIX epoch (Jan 1, 1970, UTC). The timestamp for local
-          measurements corresponds to the to the local clock and for remote
-          measurements corresponds to the timestamp indicated in the incoming
-          RTCP Sender Report (SR), Receiver Report (RR) or Extended Report (XR).
-          </p></dd>
-
-        <dt>RTCStatsType type</dt>
-        <dd><p>The type of this object.</p>
-          <p>The <dfn id="dom-rtcstats-type"><code>type</code></dfn> attribute
-          <em class="rfc2119" title="MUST">MUST</em> be initialized to the name
-          of the most specific type this <code><a>RTCStats</a></code> dictionary
-          represents.</p></dd>
-
-        <dt> DOMString         id</dt>
-        <dd><p>A unique <code>id</code> that is associated with the object that
-          was inspected to produce this <code>RTCStats</code> object.
-          Two <code>RTCStats</code> objects, extracted from two different
-          <code>RTCStatsReport</code> objects,
-          <em class="rfc2119" title="MUST">MUST</em> have the same
-          <code>id</code> if they were produced by inspecting the same
-          underlying object. User agents are free to pick any format for the
-          <code>id</code> as long as it meets the requirements above.</p></dd>
-      </dl>
-      <section id="rtcstatstype-enum*">
-        <h3>RTCStatsType enum</h3>
-
+        <!-- 
+        As per discussions: Move enum to a string that is in a registry 
         <div class="note">
           Updated the enum in [[!WEBRTC]]: to use lowercasenospacesordashes
           name convention, and added new enum values.
-        </div>
+        </div> -->
 
         <!-- TODO: point to the actual stats dictionaries  -->
-        <dl class="idl" title="enum RTCStatsType">
-          <dt>inboundrtp</dt>
+        <!-- <dl class="idl" title="DOMString RTCStatsType"> -->
+        <div>
+        <var>RTCStatsType</var> is a equal to one of the following strings defined in [IANA-TOBE]:
+
+          <dt><code>inboundrtp</code></dt>
           <dd><p>Statistics for the inbound RTP stream that is currently
             received with this <code>RTCPeerConnection</code> object. It is
             accessed by the <code><a>RTCInboundRTPStreamStats</a></code>.</p></dd>
 
-          <dt>outboundrtp</dt>
+          <dt><code>outboundrtp</code></dt>
           <dd><p>Statistics for the outbound RTP stream that is currently
             sent with this <code>RTCPeerConnection</code> object. It is
             accessed by the <code><a>RTCOutboundRTPStreamStats</a></code> </p></dd>
 
-          <dt>session</dt>
+          <dt><code>session</code></dt>
           <dd><p> Related to the <code>RTCDataChannel</code> and
             <code>RTCPeerConnection</code> object.</p></dd>
 
-          <dt>track</dt>
+          <dt><code>track</code></dt>
           <dd><p></p></dd>
 
-          <dt>transport</dt>
+          <dt><code>transport</code></dt>
           <dd><p>Transport statistics related to the
             <code>RTCPeerConnection</code> object.</p></dd>
 
-          <dt>candidatepair</dt>
+          <dt><code>candidatepair</code></dt>
           <dd><p>ICE candidate pair statistics related to the
             <code>RTCIceTransport</code> objects.</p></dd>
 
-          <dt>localcandidate</dt>
+          <dt><code>localcandidate</code></dt>
           <dd><p>ICE local candidate statistics related to the
             <code>RTCIceTransport</code> objects.</p></dd>
 
-          <dt>remotecandidate</dt>
+          <dt><code>remotecandidate</code></dt>
           <dd><p>ICE remote candidate statistics related to the
             <code>RTCIceTransport</code> objects.</p></dd>
-        </dl>
+        
+        <!-- </dl> -->
+        </div>
       </section>
 
       <section id="streamstats-dict*">


### PR DESCRIPTION
related to webrtc-ACTION-117: Move getstats and associated idl to stats doc