### PR TITLE
setting up for automatic publication on TR

### DIFF
--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,0 +1,1 @@
+index.html?specStatus=WD respec

--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,1 +1,1 @@
-index.html?specStatus=WD respec
+index.html?specStatus=WD;shortName=webrtc-stats respec

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -33,8 +33,8 @@ var respecConfig = {
       // editors, add as many as you like
       // only "name" is REQUIRED
       editors: [
-        {   name: "Harald Alvestrand",  company: "Google" },
-        {   name: "Varun Singh",        company: "Aalto University" }
+        {   name: "Harald Alvestrand",  company: "Google", w3cid: "24610" },
+        {   name: "Varun Singh",        company: "Aalto University", w3cid: "67103" }
       ],
 
       // authors, add as many as you like.


### PR DESCRIPTION
W3C is setting up a new [automated publication workflow](http://www.w3.org/2014/08/pubworkflow.html) for Working Drafts; I would like to use this document as one of the first few to be published that way, and this pull request brings some of the necessary metadata to that end.

For now, this doesn't mean that editor draft releases will be published automatically as TR Working Drafts; just that the next WD publication will be using the new workflow.