### PR TITLE
Remove protocol from src link

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -8,7 +8,7 @@
     <meta charset='utf-8'>
     <link href="webrtc-stats.css" rel="stylesheet" type="text/css" />
     <title>Identifiers for WebRTC's Statistics API</title>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'>
+    <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'>
     //<![CDATA[
     // keep this comment
     //]]>


### PR DESCRIPTION
Chrome complains about mixed content when visiting this page over HTTPS, should always use protocol agnostic links.