### PR TITLE
include respec via https

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -8,7 +8,7 @@
     <meta charset='utf-8'>
     <link href="webrtc-stats.css" rel="stylesheet" type="text/css" />
     <title>Identifiers for WebRTC's Statistics API</title>
-    <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'>
     //<![CDATA[
     // keep this comment
     //]]>


### PR DESCRIPTION
https://w3c.github.io/webrtc-stats/ refuses the insecure include of respec.