### PR TITLE
Automatic publications with Echidna+Travis and minor respec changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+branches:
+  only:
+    - gh-pages
+
+env:
+  global:
+    - URL="https://w3c.github.io/webrtc-stats/W3CTRMANIFEST"
+    - DECISION="https://lists.w3.org/Archives/Public/public-webrtc/2016Mar/0031.html"
+    - secure: "VD097GRyqSACTjhUDkrPnZv80shH2Uh5g66cxXsO95hVA1ZrLUtbwS4aQshcQrcl28uVpsJ2E/OpeHHg1HbmNv9uVdsvbnEztGxu7wm6xUi0ZXK81uYqOZtvbbnipjZywe45wTjLYJOGiYgsN9yEN1arHXAPR9lmNInt0QIf10M="
+
+script:
+  - echo "ok"
+
+after_success:
+  - [[ $TRAVIS_PULL_REQUEST == 'false' ]] && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This is the webrtc-stats document, a working document of the W3C
 WEBRTC working group.
 
-The current version of the document is at http://w3c.github.io/webrtc-stats/
+The current version of the document is at https://w3c.github.io/webrtc-stats/
 
 NOTA BENE ( http://bit.ly/VoL9Qt ) 
 =================================

--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,2 +1,2 @@
-index.html?specStatus=WD;shortName=webrtc-stats respec
+webrtc-stats.html?specStatus=WD;shortName=webrtc-stats respec
 webrtc-stats.css

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -294,7 +294,7 @@
           <p>The following example code shows the association of remote
             statistics with local statistics in a <code>RTCStats</code>
             dictionary.</p>
-          <!-- <pre class="example highlight" xml:space="preserve">
+          <!-- <pre class="example highlight">
 stats [
    dictionary (of type RTPoutboundStatsDictionary) {
       ssrc=1234
@@ -590,7 +590,7 @@ stats [
       <p>Consider the case where the user is experiencing bad sound and the
       application wants to determine if the cause of it is packet loss. The
       following example code might be used:</p>
-      <pre class="example highlight" xml:space="preserve">
+      <pre class="example highlight" >
 var baselineReport, currentReport;
 var selector = pc.getRemoteStreams()[0].getAudioTracks()[0];
 

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -20,7 +20,7 @@ var respecConfig = {
       prevED: "https://w3c.github.io/webrtc-stats/archives/20150203/webrtc-stats.html",
 
       // if there a publicly available Editor's Draft, this is the link
-      edDraftURI: "http://w3c.github.io/webrtc-stats/",
+      edDraftURI: "https://w3c.github.io/webrtc-stats/",
 
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
@@ -50,7 +50,7 @@ var respecConfig = {
       wg:           "Web Real-Time Communications Working Group",
 
       // URI of the public WG page
-      wgURI:        "http://www.w3.org/2011/04/webrtc/",
+      wgURI:        "https://www.w3.org/2011/04/webrtc/",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-webrtc",
@@ -60,8 +60,7 @@ var respecConfig = {
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      // TODO: confirm wgPatentURI
-      wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/47318/status",
+      wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/47318/status",
       localBiblio:  {
         "XRBLOCK-STATS": {
             title:    "RTCP XR Metrics for WebRTC",


### PR DESCRIPTION
This also include use of HTTPS for some URIs and a validation fix.

PR to merge after the ["Call for consensus to implement automatic publishing"](https://lists.w3.org/Archives/Public/public-webrtc/2016Mar/0031.html) March 18th 2016 deadline.