### PR TITLE
adding XRBLOCK metrics

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -538,8 +538,10 @@
                 <dd>
                   <p>
                   The cumulative number of bursts of lost RTP packets,
-                  Appendix A (e) of [[!RFC6958]]. [[!RFC3611]] recommends a Gmin
-                  (threshold) value of 16 for classifying packet loss or discard burst.
+                  Appendix A (e) of [[!RFC6958]].
+                  </p>
+                  <p>[[!RFC3611]] recommends a Gmin (threshold) value of
+                  16 for classifying packet loss or discard burst.
                   </p>
                 </dd>
                 <dt>
@@ -558,7 +560,10 @@
                 </dt>
                 <dd>
                   <p>
-                  The fraction of RTP packets lost during bursts, Appendix A (a) of [[!RFC7004]].
+                  It is the fraction of RTP packets lost during bursts to the total
+                  number of RTP packets expected in the bursts. As defined in
+                  Appendix A (a) of [[!RFC7004]], however, the actual value is
+                  reported without multiplying with 32768.
                   </p>
                 </dd>
                 <dt>
@@ -567,7 +572,10 @@
                 </dt>
                 <dd>
                   <p>
-                  The fraction of RTP packets discarded during bursts, Appendix A (e) of [[!RFC7004]].
+                  The fraction of RTP packets discarded during bursts to the total
+                  number of RTP packets expected in bursts. As defined in
+                  Appendix A (e) of [[!RFC7004]], however, the actual value is
+                  reported without multiplying with 32768.
                   </p>
                 </dd>
                 <dt>
@@ -576,7 +584,9 @@
                 </dt>
                 <dd>
                   <p>
-                  The fraction of RTP packets lost during gaps, Appendix A (b) of [[!RFC7004]].
+                  The fraction of RTP packets lost during the gap periods.
+                  Appendix A (b) of [[!RFC7004]], however, the actual value is
+                  reported without multiplying with 32768.
                   </p>
                 </dd>
                 <dt>
@@ -585,7 +595,9 @@
                 </dt>
                 <dd>
                   <p>
-                  The fraction of RTP packets discarded during gaps, Appendix A (f) of [[!RFC7004]].
+                  The fraction of RTP packets discarded during the gap periods.
+                  Appendix A (f) of [[!RFC7004]], however, the actual value is
+                  reported without multiplying with 32768.
                   </p>
                 </dd>
 

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -541,7 +541,7 @@
                   Appendix A (e) of [[!RFC6958]].
                   </p>
                   <p>[[!RFC3611]] recommends a Gmin (threshold) value of
-                  16 for classifying packet loss or discard burst.
+                  16 for classifying a sequence of packet losses or discards as a burst.
                   </p>
                 </dd>
                 <dt>
@@ -560,10 +560,10 @@
                 </dt>
                 <dd>
                   <p>
-                  It is the fraction of RTP packets lost during bursts to the total
+                  The fraction of RTP packets lost during bursts to the total
                   number of RTP packets expected in the bursts. As defined in
                   Appendix A (a) of [[!RFC7004]], however, the actual value is
-                  reported without multiplying with 32768.
+                  reported without multiplying by 32768.
                   </p>
                 </dd>
                 <dt>
@@ -575,7 +575,7 @@
                   The fraction of RTP packets discarded during bursts to the total
                   number of RTP packets expected in bursts. As defined in
                   Appendix A (e) of [[!RFC7004]], however, the actual value is
-                  reported without multiplying with 32768.
+                  reported without multiplying by 32768.
                   </p>
                 </dd>
                 <dt>
@@ -586,7 +586,7 @@
                   <p>
                   The fraction of RTP packets lost during the gap periods.
                   Appendix A (b) of [[!RFC7004]], however, the actual value is
-                  reported without multiplying with 32768.
+                  reported without multiplying by 32768.
                   </p>
                 </dd>
                 <dt>
@@ -597,7 +597,7 @@
                   <p>
                   The fraction of RTP packets discarded during the gap periods.
                   Appendix A (f) of [[!RFC7004]], however, the actual value is
-                  reported without multiplying with 32768.
+                  reported without multiplying by 32768.
                   </p>
                 </dd>
 

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -791,7 +791,8 @@ stats [
              unsigned long       framesDecoded;
              unsigned long       framesDropped;
              unsigned long       framesCorrupted;
-             unsigned long       framesLost;
+             unsigned long       partialFramesLost;
+             unsigned long       fullFramesLost;
              double              audioLevel;
              double              echoReturnLoss;
              double              echoReturnLossEnhancement;
@@ -906,8 +907,10 @@ stats [
                 </dt>
                 <dd>
                   <p>
-                    Only valid for video. Same definition as <code>droppedVideoFrames</code> in
-                    Section 5 of [[!MEDIA-SOURCE]].
+                    Only valid for video. It is the total number of frames dropped
+                    predecode or dropped because the frame missed its display
+                    deadline for this SSRC. It is the same definition as
+                    <code>droppedVideoFrames</code> in Section 5 of [[!MEDIA-SOURCE]].
                   </p>
                 </dd>
                 <dt>
@@ -916,18 +919,31 @@ stats [
                 </dt>
                 <dd>
                   <p>
-                    Only valid for video. Same definition as <code>corruptedVideoFrames</code> in
-                    Section 5 of [[!MEDIA-SOURCE]].
+                    Only valid for video. It is the total number of corrupted frames
+                    that have been detected for this SSRC. It is the same definition as
+                    <code>corruptedVideoFrames</code> in Section 5 of [[!MEDIA-SOURCE]].
                   </p>
                 </dd>
                 <dt>
-                  <dfn><code>framesLost</code></dfn> of type <span class=
+                  <dfn><code>partialFramesLost</code></dfn> of type <span class=
                   "idlMemberType"><a>unsigned long</a></span>
                 </dt>
                 <dd>
                   <p>
-                    Only valid for video. <code>framesLost</code> is the cumulative number of
-                    full frames lost, as defined in Appendix A (i) of [[!RFC7004]].
+                    Only valid for video. <code>partialFramesLost</code> is the
+                    cumulative number of partial frames lost, as defined in
+                    Appendix A (j) of [[!RFC7004]].
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>fullFramesLost</code></dfn> of type <span class=
+                  "idlMemberType"><a>unsigned long</a></span>
+                </dt>
+                <dd>
+                  <p>
+                    Only valid for video. <code>fullFramesLost</code> is the
+                    cumulative number of full frames lost, as defined in
+                    Appendix A (i) of [[!RFC7004]].
                   </p>
                 </dd>
                 <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -419,6 +419,14 @@
              double             fractionLost;
              unsigned long      packetsDiscarded;
              unsigned long      packetsRepaired;
+             unsigned long      burstPacketsLost;
+             unsigned long      burstPacketsDiscarded;
+             unsigned long      burstLossCount;
+             unsigned long      burstDiscardCount;
+             double             burstLossRate;
+             double             burstDiscardRate;
+             double             gapLossRate;
+             double             gapDiscardRate;
 };</pre>
             <section>
               <h2>
@@ -503,6 +511,84 @@
                   [[!RFC7509]] section 3.1 and Appendix A.b.
                   </p>
                 </dd>
+                <dt>
+                  <dfn><code>burstPacketsLost</code></dfn> of type <span class=
+                  "idlMemberType"><a>unsigned long</a></span>
+                </dt>
+                <dd>
+                  <p>
+                  The cumulative number of RTP packets lost during loss
+                  bursts, Appendix A (c) of [[!RFC6958]].
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>burstPacketsDiscarded</code></dfn> of type <span class=
+                  "idlMemberType"><a>unsigned long</a></span>
+                </dt>
+                <dd>
+                  <p>
+                  The cumulative number of RTP packets discarded during
+                  discard bursts, Appendix A (b) of [[!RFC7003]].
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>burstLossCount</code></dfn> of type <span class=
+                  "idlMemberType"><a>unsigned long</a></span>
+                </dt>
+                <dd>
+                  <p>
+                  The cumulative number of bursts of lost RTP packets,
+                  Appendix A (e) of [[!RFC6958]]. [[!RFC3611]] recommends a Gmin
+                  (threshold) value of 16 for classifying packet loss or discard burst.
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>burstDiscardCount</code></dfn> of type <span class=
+                  "idlMemberType"><a>unsigned long</a></span>
+                </dt>
+                <dd>
+                  <p>
+                  The cumulative number of bursts of discarded RTP packets,
+                  Appendix A (e) of [[!burst-gap-discard]].
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>burstLossRate</code></dfn> of type <span class=
+                  "idlMemberType"><a>double</a></span>
+                </dt>
+                <dd>
+                  <p>
+                  The fraction of RTP packets lost during bursts, Appendix A (a) of [[!RFC7004]].
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>burstDiscardRate</code></dfn> of type <span class=
+                  "idlMemberType"><a>double</a></span>
+                </dt>
+                <dd>
+                  <p>
+                  The fraction of RTP packets discarded during bursts, Appendix A (e) of [[!RFC7004]].
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>gapLossRate</code></dfn> of type <span class=
+                  "idlMemberType"><a>double</a></span>
+                </dt>
+                <dd>
+                  <p>
+                  The fraction of RTP packets lost during gaps, Appendix A (b) of [[!RFC7004]].
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>gapDiscardRate</code></dfn> of type <span class=
+                  "idlMemberType"><a>double</a></span>
+                </dt>
+                <dd>
+                  <p>
+                  The fraction of RTP packets discarded during gaps, Appendix A (f) of [[!RFC7004]].
+                  </p>
+                </dd>
+
               </dl>
             </section>
           </div>
@@ -705,6 +791,7 @@ stats [
              unsigned long       framesDecoded;
              unsigned long       framesDropped;
              unsigned long       framesCorrupted;
+             unsigned long       framesLost;
              double              audioLevel;
              double              echoReturnLoss;
              double              echoReturnLossEnhancement;
@@ -829,8 +916,18 @@ stats [
                 </dt>
                 <dd>
                   <p>
-                    Only valid for video.Same definition as <code>corruptedVideoFrames</code> in
+                    Only valid for video. Same definition as <code>corruptedVideoFrames</code> in
                     Section 5 of [[!MEDIA-SOURCE]].
+                  </p>
+                </dd>
+                <dt>
+                  <dfn><code>framesLost</code></dfn> of type <span class=
+                  "idlMemberType"><a>unsigned long</a></span>
+                </dt>
+                <dd>
+                  <p>
+                    Only valid for video. <code>framesLost</code> is the cumulative number of
+                    full frames lost, as defined in Appendix A (i) of [[!RFC7004]].
                   </p>
                 </dd>
                 <dt>

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -93,6 +93,18 @@ var respecConfig = {
             ],
             status:   "Internet Draft",
             publisher:  "IETF"
+        },
+        "burst-gap-discard": {
+            title:    "RTCP XR Block for Independent Reporting of Burst/Gap Discard Metric",
+            href:     "https://tools.ietf.org/html/draft-ietf-xrblock-independent-burst-gap-discard",
+            authors:  [
+                "Varun Singh",
+                "Colin Perkins",
+                "Alan Clark",
+                "Rachel Huang"
+            ],
+            status:   "Internet Draft",
+            publisher:  "IETF"
         }
       },
       afterEnd: function markFingerprinting () {


### PR DESCRIPTION
Moved metrics from: https://tools.ietf.org/html/draft-ietf-xrblock-rtcweb-rtcp-xr-metrics
Fixes #35.