### PR TITLE
Adding isRemote to RTCIceCandidateStats.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1320,6 +1320,7 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCIceCandidateStats : RTCStats {
+             boolean                  isRemote;
              DOMString                ip;
              long                     port;
              DOMString                protocol;
@@ -1333,6 +1334,16 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCIceCandidateStats" data-dfn-for="RTCIceCandidateStats"
             class="dictionary-members">
+              <dt>
+                <dfn><code>isRemote</code></dfn> of type <span class=
+                "idlMemberType"><a>boolean</a></span>
+              </dt>
+              <dd>
+                <p>
+                  <code>false</code> indicates that this represents a local candidate;
+                  <code>true</code> indicates that this represents a remote candidate.
+                </p>
+              </dd>
               <dt>
                 <dfn><code>ip</code></dfn> of type <span class=
                 "idlMemberType"><a>DOMString</a></span>


### PR DESCRIPTION
Used to differentiate local and remote ICE candidates, which is needed
if the candidate is not paired.

Fixes issue #91.