### PR TITLE
Adding minor clarification regarding stats object lifetime.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -183,11 +183,11 @@
           Lifetime of stats objects
         </h3>
         <p>
-          The general rule is that stats objects are created at the same time as the underlying
-          object they report on, and once created, they exist for the lifetime of the PeerConnection
-          that contains them, even when the underlying object is stopped or deleted. This is
-          important in order to report consistently on short-lived objects and to be able to report
-          totals over the lifetime of a PeerConnection.
+          The general rule is that stats objects are considered to be created at the same time as
+          the underlying object they report on, and once created, they exist for the lifetime of the
+          PeerConnection that contains them, even when the underlying object is stopped or deleted.
+          This is important in order to report consistently on short-lived objects and to be able to
+          report totals over the lifetime of a PeerConnection.
         </p>
         <p>
           When an object is closed or deleted, the <code>timestamp</code> member of the stats

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -183,10 +183,11 @@
           Lifetime of stats objects
         </h3>
         <p>
-          The general rule is that stats objects, once created, exist for the lifetime of the
-          PeerConnection that contains them, even when the underlying object they report on is
-          stopped or deleted. This is important in order to report consistently on short-lived
-          objects and to be able to report totals over the lifetime of a PeerConnection.
+          The general rule is that stats objects are created at the same time as the underlying
+          object they report on, and once created, they exist for the lifetime of the PeerConnection
+          that contains them, even when the underlying object is stopped or deleted. This is
+          important in order to report consistently on short-lived objects and to be able to report
+          totals over the lifetime of a PeerConnection.
         </p>
         <p>
           When an object is closed or deleted, the <code>timestamp</code> member of the stats


### PR DESCRIPTION
A stats object is created at the same time as the underlying object; NOT
when getStats is called. That means that if an underlying object is
created and destroyed in-between an application calling getStats, it
should still appear in the stats.