### PR TITLE
Replace RTCTransportStats.active with .dtlsState

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -106,7 +106,7 @@
       </p>
       <p>
         The terms <dfn>RTCPeerConnection</dfn>, <dfn>RTCDataChannel</dfn>,
-        <dfn>RTCDtlsTransport</dfn>. <dfn>RTCDtlsTransportState</dfn> and
+        <dfn>RTCDtlsTransport</dfn>, <dfn>RTCDtlsTransportState</dfn> and
         <dfn>RTCIceTransport</dfn> are defined in [[!WEBRTC]].
       </p>
       <p>
@@ -1350,7 +1350,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Set to the current value of the "state" field of the underlying RTCDtlsTransport.
+                  Set to the current value of the "state" attribute of the underlying
+                  RTCDtlsTransport.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1204,7 +1204,7 @@ enum RTCStatsType {
              DOMString           label;
              DOMString           protocol;
              long                datachannelid;
-             RTCDataChannelState state;
+             RTCDataChannelState dtlsState;
              unsigned long       messagesSent;
              unsigned long long  bytesSent;
              unsigned long       messagesReceived;
@@ -1236,7 +1236,7 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn><code>state</code></dfn> of type <span class=
+                <dfn><code>dtlsState</code></dfn> of type <span class=
                 "idlMemberType"><a>RTCDataChannelState</a></span>
               </dt>
               <dd></dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1204,7 +1204,7 @@ enum RTCStatsType {
              DOMString           label;
              DOMString           protocol;
              long                datachannelid;
-             RTCDataChannelState dtlsState;
+             RTCDataChannelState state;
              unsigned long       messagesSent;
              unsigned long long  bytesSent;
              unsigned long       messagesReceived;
@@ -1236,7 +1236,7 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn><code>dtlsState</code></dfn> of type <span class=
+                <dfn><code>state</code></dfn> of type <span class=
                 "idlMemberType"><a>RTCDataChannelState</a></span>
               </dt>
               <dd></dd>
@@ -1302,7 +1302,7 @@ enum RTCStatsType {
              unsigned long long    bytesSent;
              unsigned long long    bytesReceived;
              DOMString             rtcpTransportStatsId;
-             RTCDtlsTransportState state;
+             RTCDtlsTransportState dtlsState;
              DOMString             selectedCandidatePairId;
              DOMString             localCertificateId;
              DOMString             remoteCertificateId;
@@ -1345,7 +1345,7 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn><code>state</code></dfn> of type <span class=
+                <dfn><code>dtlsState</code></dfn> of type <span class=
                 "idlMemberType"><a>RTCDtlsTransportState</a></span>
               </dt>
               <dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -106,7 +106,8 @@
       </p>
       <p>
         The terms <dfn>RTCPeerConnection</dfn>, <dfn>RTCDataChannel</dfn>,
-        <dfn>RTCDtlsTransport</dfn> and <dfn>RTCIceTransport</dfn> are defined in [[!WEBRTC]].
+        <dfn>RTCDtlsTransport</dfn>. <dfn>RTCDtlsTransportState</dfn> and
+        <dfn>RTCIceTransport</dfn> are defined in [[!WEBRTC]].
       </p>
       <p>
         The term <dfn>RTP stream</dfn> is defined in [[RFC7656]] section 2.1.10.
@@ -1298,13 +1299,13 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCTransportStats : RTCStats {
-             unsigned long long bytesSent;
-             unsigned long long bytesReceived;
-             DOMString          rtcpTransportStatsId;
-             boolean            activeConnection;
-             DOMString          selectedCandidatePairId;
-             DOMString          localCertificateId;
-             DOMString          remoteCertificateId;
+             unsigned long long    bytesSent;
+             unsigned long long    bytesReceived;
+             DOMString             rtcpTransportStatsId;
+             RTCDtlsTransportState state;
+             DOMString             selectedCandidatePairId;
+             DOMString             localCertificateId;
+             DOMString             remoteCertificateId;
 };</pre>
           <section>
             <h2>
@@ -1344,12 +1345,12 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn><code>activeConnection</code></dfn> of type <span class=
-                "idlMemberType"><a>boolean</a></span>
+                <dfn><code>state</code></dfn> of type <span class=
+                "idlMemberType"><a>RTCDtlsTransportState</a></span>
               </dt>
               <dd>
                 <p>
-                  Set to <code>true</code> when transport is active.
+                  Set to the current value of the "state" field of the underlying RTCDtlsTransport.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
"active" was not well defined. "state" is more specific, and
is well defined.
Closes #67