### PR TITLE
Added more datachannel counters, with definitions.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -909,10 +909,10 @@ enum RTCStatsType {
         </h3>
         <div>
           <pre class="idl">dictionary RTCPeerConnectionStats : RTCStats {
-             unsigned long dataChannelsOpened;
+            unsigned long dataChannelsOpened;
             unsigned long dataChannelsClosed;
+            unsigned long dataChannelsRequested;
             unsigned long dataChannelsAccepted;
-            unsigned long dataChannelsSignalledClosed;
 };</pre>
           <section>
             <h2>
@@ -926,8 +926,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique DataChannels returned from a successful
-                  createDataChannel() call.
+                  Represents the number of unique DataChannels that have entered the "open" state
+                  during their lifetime.
                 </p>
               </dd>
               <dt>
@@ -936,7 +936,21 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique DataChannels closed using the close() function.
+                  Represents the number of unique DataChannels that have left the "open" state
+                  during their lifetime (due to being closed by either end or the underlying
+                  transport being closed). DataChannels that transition from "connecting" to
+                  "closing" or "closed" without ever being "open" are not counted in this number.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>dataChannelsRequested</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the number of unique DataChannels returned from a successful
+                  createDataChannel() call on the PeerConnection. If the underlying data transport
+                  is not established, these may be in "connecting" state.
                 </p>
               </dd>
               <dt>
@@ -945,25 +959,19 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique DataChannels signalled in a "datachannel" event
-                  on the PeerConnection.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>dataChannelsSignalledClosed</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the number of unique DataChannels signalled as closed in a "close"
-                  event on the RTCDataChannel object.
+                  Represents the number of unique DataChannels signaled in a "datachannel" event on
+                  the PeerConnection.
                 </p>
               </dd>
             </dl>
             <p>
               The total number of open data channels at any time can be calculated as
-              dataChannelsOpened + dataChannelsAccepted - dataChannelsClosed -
-              dataChannelsSignalledClosed.
+              dataChannelsOpened - dataChannelsClosed. This number is always positive.
+            </p>
+            <p>
+              The sum of dataChannelsRequested and dataChannelsAccepted is always greater than or
+              equal to dataChannelsOpened - the difference is equal to the number of channels that
+              have been requested, but have not reached the "open" state.
             </p>
           </section>
         </div>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -950,7 +950,7 @@ enum RTCStatsType {
                 <p>
                   Represents the number of unique DataChannels returned from a successful
                   createDataChannel() call on the PeerConnection. If the underlying data transport
-                  is not established, these may be in "connecting" state.
+                  is not established, these may be in the "connecting" state.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -926,7 +926,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique datachannels returned from a successful
+                  Represents the number of unique DataChannels returned from a successful
                   createDataChannel() call.
                 </p>
               </dd>
@@ -936,7 +936,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique datachannels closed using the close() function.
+                  Represents the number of unique DataChannels closed using the close() function.
                 </p>
               </dd>
               <dt>
@@ -945,7 +945,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique datachannels signalled in a "datachannel" event
+                  Represents the number of unique DataChannels signalled in a "datachannel" event
                   on the PeerConnection.
                 </p>
               </dd>
@@ -955,8 +955,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique datachannels signalled in a "close" event on the
-                  datachannel object.
+                  Represents the number of unique DataChannels signalled as closed in a "close"
+                  event on the RTCDataChannel object.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -910,7 +910,9 @@ enum RTCStatsType {
         <div>
           <pre class="idl">dictionary RTCPeerConnectionStats : RTCStats {
              unsigned long dataChannelsOpened;
-             unsigned long dataChannelsClosed;
+            unsigned long dataChannelsClosed;
+            unsigned long dataChannelsAccepted;
+            unsigned long dataChannelsSignalledClosed;
 };</pre>
           <section>
             <h2>
@@ -924,7 +926,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique datachannels opened.
+                  Represents the number of unique datachannels returned from a successful
+                  createDataChannel() call.
                 </p>
               </dd>
               <dt>
@@ -933,10 +936,35 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the number of unique datachannels closed.
+                  Represents the number of unique datachannels closed using the close() function.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>dataChannelsAccepted</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the number of unique datachannels signalled in a "datachannel" event
+                  on the PeerConnection.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>dataChannelsSignalledClosed</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the number of unique datachannels signalled in a "close" event on the
+                  datachannel object.
                 </p>
               </dd>
             </dl>
+            <p>
+              The total number of open data channels at any time can be calculated as
+              dataChannelsOpened + dataChannelsAccepted - dataChannelsClosed -
+              dataChannelsSignalledClosed.
+            </p>
           </section>
         </div>
       </section>


### PR DESCRIPTION
This splits the datachannel open events into outgoing and incoming,
and the close events into "I close" and "others close".

Closes #79