### PR TITLE
Define audio level rigidly

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1203,15 +1203,17 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio, and the value is between 0..1 (linear), where 1.0
+                  Only valid for audio. The value is between 0..1 (linear), where 1.0
                   represents <code>0 dBov</code>, 0 represents silence, and 0.5 represents
                   approximately 6 dBSPL change in the sound pressure level from 0 dBov.
                 </p>
                 <p>
-                  The "audio level" value defined in [[!RFC6464]] (defined as 0..127, where 0
-                  represents 0 dBov, 126 reprsents -126 dBov and 127 represents silence) can be
-                  obtained by the calculation given in appendix A of [[RFC6465]]: level =
-                  -log10(audioLevel) * 20.
+                  The "audio level" value defined in [[RFC6464]] and used in the
+		  RTCRtpContributingSource.audioLevel of [[WEBRTC]] (defined as 0..127, where 0
+                  represents 0 dBov, 126 represents -126 dBov and 127 represents silence) is
+                  obtained by the calculation given in appendix A of [[!RFC6465]]: informally, level =
+                  -round(log10(audioLevel) * 20), with audioLevel 0.0 and values below 127 mapped
+		  to 127.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1204,7 +1204,14 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Only valid for audio, and the value is between 0..1 (linear), where 1.0
-                  represents <code>0 dBov</code>. Calculated as defined in [[!RFC6464]].
+                  represents <code>0 dBov</code>, 0 represents silence, and 0.5 represents
+                  approximately 6 dBSPL change in the sound pressure level from 0 dBov.
+                </p>
+                <p>
+                  The "audio level" value defined in [[!RFC6464]] (defined as 0..127, where 0
+                  represents 0 dBov, 126 reprsents -126 dBov and 127 represents silence) can be
+                  obtained by the calculation given in appendix A of [[RFC6465]]: level =
+                  -log10(audioLevel) * 20.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
This definition should match the one in mediacapture-main for "volume",
and also shows how to relate it to RFC 6465 levels.

Fixes #81 