### PR TITLE
frameWidth/frameHeight: use last decoded value

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1136,8 +1136,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video MediaStreamTracks and represents the width of the video
-                  frame for this track.
+                  Only valid for video MediaStreamTracks and represents the width of the last
+                  processed video frame for this track. Before the first frame is processed this
+                  attribute is missing.
                 </p>
               </dd>
               <dt>
@@ -1146,8 +1147,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video MediaStreamTracks and represents the height of the video
-                  frame for this MediaStreamTrack.
+                  Only valid for video MediaStreamTracks and represents the height of the last
+                  processed video frame for this track. Before the first frame is processed this
+                  attribute is missing.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
The stats for the frameWidth and frameHeight should be for the last
decoded frame. This is for consistency with the MediaElement width/height
which does not change when there are temporarily no frames received.