### PR TITLE
Adding remoteTimestamp to RTCRtpStreamStats.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -416,7 +416,6 @@ enum RTCStatsType {
              unsigned long       ssrc;
              DOMString           associateStatsId;
              boolean             isRemote = false;
-             DOMHighResTimeStamp remoteTimestamp;
              DOMString           mediaType;
              DOMString           trackId;
              DOMString           transportId;
@@ -462,26 +461,6 @@ enum RTCStatsType {
                   <code>false</code> indicates that the statistics are measured locally, while
                   <code>true</code> indicates that the measurements were done at the remote
                   endpoint and reported in an RTCP RR/XR.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>remoteTimestamp</code></dfn> of type <span class=
-                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Present if <code>isRemote</code> is <code>true</code>,
-                  <code>remoteTimestamp</code>, of type
-                  <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]],
-                  represents the remote timestamp at which these statistics
-                  were sent by the remote endpoint. This differs from
-                  <code>timestamp</code>, which represents the time at which
-                  the statistics were generated or received by the local
-                  endpoint. The <code>remoteTimestamp</code>, if present, is
-                  derived from the NTP timestamp in an RTCP SR packet, which
-                  reflects the remote endpoint's clock. That clock may not be
-                  synchronized with the local clock. The time is relative to
-                  the UNIX epoch (Jan 1, 1970, UTC).
                 </p>
               </dd>
               <dt>
@@ -897,6 +876,7 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCOutboundRTPStreamStats : RTCRTPStreamStats {
+             DOMHighResTimeStamp remoteTimestamp;
              unsigned long      packetsSent;
              unsigned long long bytesSent;
              double             targetBitrate;
@@ -909,6 +889,26 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCOutboundRTPStreamStats" data-dfn-for="RTCOutboundRTPStreamStats"
             class="dictionary-members">
+              <dt>
+                <dfn><code>remoteTimestamp</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Present if <code>isRemote</code> is <code>true</code>,
+                  <code>remoteTimestamp</code>, of type
+                  <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]],
+                  represents the remote timestamp at which these statistics
+                  were sent by the remote endpoint. This differs from
+                  <code>timestamp</code>, which represents the time at which
+                  the statistics were generated or received by the local
+                  endpoint. The <code>remoteTimestamp</code>, if present, is
+                  derived from the NTP timestamp in an RTCP SR packet, which
+                  reflects the remote endpoint's clock. That clock may not be
+                  synchronized with the local clock. The time is relative to
+                  the UNIX epoch (Jan 1, 1970, UTC).
+                </p>
+              </dd>
               <dt>
                 <dfn><code>packetsSent</code></dfn> of type <span class="idlMemberType"><a>unsigned
                 long</a></span>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -474,11 +474,14 @@ enum RTCStatsType {
                   <code>remoteTimestamp</code>, of type
                   <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]],
                   represents the remote timestamp at which these statistics
-                  were sent by the remote endpoint (e.g., through RTCP). This
-                  differs from <code>timestamp</code>, which represents the
-                  time at which the statistics were received by the local
-                  endpoint. The time is relative to the UNIX epoch (Jan 1,
-                  1970, UTC).
+                  were sent by the remote endpoint. This differs from
+                  <code>timestamp</code>, which represents the time at which
+                  the statistics were received by the local endpoint. This
+                  timestamp, if present, is derived from the NTP timestamp in
+                  an RTCP SR packet, which reflects the remote endpoint's
+                  clock. That clock may not be synchronized with the local
+                  clock. The time is relative to the UNIX epoch (Jan 1, 1970,
+                  UTC).
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -476,12 +476,12 @@ enum RTCStatsType {
                   represents the remote timestamp at which these statistics
                   were sent by the remote endpoint. This differs from
                   <code>timestamp</code>, which represents the time at which
-                  the statistics were received by the local endpoint. This
-                  timestamp, if present, is derived from the NTP timestamp in
-                  an RTCP SR packet, which reflects the remote endpoint's
-                  clock. That clock may not be synchronized with the local
-                  clock. The time is relative to the UNIX epoch (Jan 1, 1970,
-                  UTC).
+                  the statistics were received by the local endpoint. The
+                  <code>remoteTimestamp</code>, if present, is derived from the
+                  NTP timestamp in an RTCP SR packet, which reflects the remote
+                  endpoint's clock. That clock may not be synchronized with the
+                  local clock. The time is relative to the UNIX epoch (Jan 1,
+                  1970, UTC).
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -476,12 +476,12 @@ enum RTCStatsType {
                   represents the remote timestamp at which these statistics
                   were sent by the remote endpoint. This differs from
                   <code>timestamp</code>, which represents the time at which
-                  the statistics were received by the local endpoint. The
-                  <code>remoteTimestamp</code>, if present, is derived from the
-                  NTP timestamp in an RTCP SR packet, which reflects the remote
-                  endpoint's clock. That clock may not be synchronized with the
-                  local clock. The time is relative to the UNIX epoch (Jan 1,
-                  1970, UTC).
+                  the statistics were generated or received by the local
+                  endpoint. The <code>remoteTimestamp</code>, if present, is
+                  derived from the NTP timestamp in an RTCP SR packet, which
+                  reflects the remote endpoint's clock. That clock may not be
+                  synchronized with the local clock. The time is relative to
+                  the UNIX epoch (Jan 1, 1970, UTC).
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -413,18 +413,19 @@ enum RTCStatsType {
         </h3>
         <div>
           <pre class="idl">dictionary RTCRTPStreamStats : RTCStats {
-             unsigned long      ssrc;
-             DOMString          associateStatsId;
-             boolean            isRemote = false;
-             DOMString          mediaType;
-             DOMString          trackId;
-             DOMString          transportId;
-             DOMString          codecId;
-             unsigned long      firCount;
-             unsigned long      pliCount;
-             unsigned long      nackCount;
-             unsigned long      sliCount;
-             unsigned long long qpSum;
+             unsigned long       ssrc;
+             DOMString           associateStatsId;
+             boolean             isRemote = false;
+             DOMHighResTimeStamp remoteTimestamp;
+             DOMString           mediaType;
+             DOMString           trackId;
+             DOMString           transportId;
+             DOMString           codecId;
+             unsigned long       firCount;
+             unsigned long       pliCount;
+             unsigned long       nackCount;
+             unsigned long       sliCount;
+             unsigned long long  qpSum;
 };</pre>
           <section>
             <h2>
@@ -461,6 +462,23 @@ enum RTCStatsType {
                   <code>false</code> indicates that the statistics are measured locally, while
                   <code>true</code> indicates that the measurements were done at the remote
                   endpoint and reported in an RTCP RR/XR.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>remoteTimestamp</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Present if <code>isRemote</code> is <code>true</code>,
+                  <code>remoteTimestamp</code>, of type
+                  <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]],
+                  represents the remote timestamp at which these statistics
+                  were sent by the remote endpoint (e.g., through RTCP). This
+                  differs from <code>timestamp</code>, which represents the
+                  time at which the statistics were received by the local
+                  endpoint. The time is relative to the UNIX epoch (Jan 1,
+                  1970, UTC).
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Since `timestamp` always refers to the locally measured timestamp,
as decided by the working group, this is where the remote timestamp can
be found.

See: https://github.com/w3c/webrtc-pc/issues/729