### PR TITLE
Remove separation of received consent and connectivity requests.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -433,8 +433,8 @@ enum RTCStatsType {
             <dl data-link-for="RTCRTPStreamStats" data-dfn-for="RTCRTPStreamStats" class=
             "dictionary-members">
               <dt>
-                <dfn><code>ssrc</code></dfn> of type <span class="idlMemberType"><a>unsigned long
-                </a></span>
+                <dfn><code>ssrc</code></dfn> of type <span class="idlMemberType"><a>unsigned
+                long</a></span>
               </dt>
               <dd>
                 <p>
@@ -561,7 +561,7 @@ enum RTCStatsType {
                 <p>
                   The definition of QP value depends on the <a>codec</a>; for VP8, the QP value is
                   the value carried in the frame header as the syntax element "y_ac_qi", and
-                  defined in [[RFC6386]] section 19.2. Its range is 0..127.
+                  defined in [[RFC6386]] section 19.2. Its range is 0..127. 
                   <!-- Need appropriate references for VP9 and H.264 -->
                 </p>
                 <p>
@@ -1630,12 +1630,8 @@ enum RTCStatsType {
              unsigned long long            requestsSent;
              unsigned long long            responsesReceived;
              unsigned long long            responsesSent;
-             unsigned long long            retransmissionsReceived;
              unsigned long long            retransmissionsSent;
-             unsigned long long            consentRequestsReceived;
              unsigned long long            consentRequestsSent;
-             unsigned long long            consentResponsesReceived;
-             unsigned long long            consentResponsesSent;
 };</pre>
           <section>
             <h2>
@@ -1749,11 +1745,11 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the sum of all round trip time measurements in seconds since the
-                  beginning of the session, based on both STUN connectivity check
-                  [[!STUN-PATH-CHAR]] responses (responsesReceived) and consent [[!RFC7675]]
-                  responses (consentResponsesReceived). The average round trip time can be computed
-                  from <code>totalRoundTripTime</code> by dividing it by
-                  (<code>responsesReceived</code> + <code>consentResponsesReceived</code>).
+                  beginning of the session, based on STUN connectivity check [[!STUN-PATH-CHAR]]
+                  responses (responsesReceived), including those that reply to requests that are
+                  sent in order to verify consent [[!RFC7675]] responses. The average round trip
+                  time can be computed from <code>totalRoundTripTime</code> by dividing it by
+                  <code>responsesReceived</code>.
                 </p>
               </dd>
               <dt>
@@ -1763,7 +1759,8 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the latest round trip time measured in seconds, computed from both
-                  STUN connectivity checks [[!STUN-PATH-CHAR]] and consent responses [[!RFC7675]].
+                  STUN connectivity checks [[!STUN-PATH-CHAR]], including those that are sent for
+                  consent verification [[!RFC7675]].
                 </p>
               </dd>
               <dt>
@@ -1799,7 +1796,9 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the total number of connectivity check requests received (including
-                  retransmissions).
+                  retransmissions). It is impossible for the receiver to tell whether the request
+                  was sent in order to check connectivity or check consent, so all connectivity
+                  checks requests are counted here.
                 </p>
               </dd>
               <dt>
@@ -1827,16 +1826,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the total number of connectivity check responses sent.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>retransmissionsReceived</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of connectivity check retransmissions received.
+                  Represents the total number of connectivity check responses sent. Since we cannot
+                  distinguish connectivity check requests and consent requests, all responses are
+                  counted.
                 </p>
               </dd>
               <dt>
@@ -1849,39 +1841,12 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn><code>consentRequestsReceived</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of consent requests received.
-                </p>
-              </dd>
-              <dt>
                 <dfn><code>consentRequestsSent</code></dfn> of type <span class=
                 "idlMemberType"><a>unsigned long long</a></span>
               </dt>
               <dd>
                 <p>
                   Represents the total number of consent requests sent.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>consentResponsesReceived</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of consent responses received.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>consentResponsesSent</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of consent responses sent.
                 </p>
               </dd>
             </dl>
@@ -2124,7 +2089,7 @@ function logError(error) {
       </h3>
       <p>
         Some stats identifiers may expose personally identifiable information, for example the IP
-        addresses of the participating endpoints when a TURN relay is not used.
+        addresses of the participating endpoints when a TURN relay is not used. 
         <!-- TODO: add guidance on how to not expose this information? -->
       </p>
     </section>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1630,6 +1630,7 @@ enum RTCStatsType {
              unsigned long long            requestsSent;
              unsigned long long            responsesReceived;
              unsigned long long            responsesSent;
+             unsigned long long            retransmissionsReceived;
              unsigned long long            retransmissionsSent;
              unsigned long long            consentRequestsSent;
 };</pre>
@@ -1832,12 +1833,24 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
+                <dfn><code>retransmissionsReceived</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the total number of connectivity check request retransmissions
+                  received. Retransmissions are defined as connectivity check requests with a
+                  TRANSACTION_TRANSMIT_COUNTER attribute where the "req" field is larger than 1, as
+                  defined in [[!RFC7982]].
+                </p>
+              </dd>
+              <dt>
                 <dfn><code>retransmissionsSent</code></dfn> of type <span class=
                 "idlMemberType"><a>unsigned long long</a></span>
               </dt>
               <dd>
                 <p>
-                  Represents the total number of connectivity check retransmissions sent.
+                  Represents the total number of connectivity check request retransmissions sent.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1748,8 +1748,8 @@ enum RTCStatsType {
                   Represents the sum of all round trip time measurements in seconds since the
                   beginning of the session, based on STUN connectivity check [[!STUN-PATH-CHAR]]
                   responses (responsesReceived), including those that reply to requests that are
-                  sent in order to verify consent [[!RFC7675]] responses. The average round trip
-                  time can be computed from <code>totalRoundTripTime</code> by dividing it by
+                  sent in order to verify consent [[!RFC7675]]. The average round trip time can be
+                  computed from <code>totalRoundTripTime</code> by dividing it by
                   <code>responsesReceived</code>.
                 </p>
               </dd>


### PR DESCRIPTION
It seems to be impossible for a receiver of such a request to tell
why it was sent, so we should not try to differentiate on either
incoming requests, outgoing responses or incoming responses.

Fixes #96