### PR TITLE
Bandwidth estimations again (Issue 97 redux)

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1862,7 +1862,6 @@ enum RTCStatsType {
                 <p>
                   Represents the timestamp at which the last packet
                   was sent on this particular candidate pair.
-                  It is of the type <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]].
                 </p>
               </dd>
               <dt>
@@ -1873,7 +1872,6 @@ enum RTCStatsType {
                 <p>
                   Represents the timestamp at which the last packet
                   was received on this particular candidate pair.
-                  It is of the type <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]].
                 </p>
               </dd>
               <dt>
@@ -1914,13 +1912,12 @@ enum RTCStatsType {
                   in bits per second and the bitrate is calculated over a 1 second window.
                 </p>
                 <p>
-                  Implementations that do not calculate a sender-side estimate should leave this undefined.
-                  Additionally, the value should be undefined for candidate pairs that were never used.
+                  Implementations that do not calculate a sender-side estimate MUST leave this undefined.
+                  Additionally, the value MUST be undefined for candidate pairs that were never used.
                   For pairs in use, the estimate is normally no lower than the bitrate for
-                  the packets sent at <dfn>lastPacketSentTimestamp</dfn>, but might be higher.
+                  the packets sent at <code>lastPacketSentTimestamp</code>, but might be higher.
                   For candidate pairs that are not currently in use but were used before,
-                  implementations can use the last calculated estimate provided that no further
-                  packets are sent.
+                  implementations MUST return undefined.
                 </p>
               </dd>
               <dt>
@@ -1936,13 +1933,12 @@ enum RTCStatsType {
                   in bits per second and the bitrate is calculated over a 1 second window.
                 </p>
                 <p>
-                  Implementations that do not calculate a receiver-side estimate should leave this undefined.
+                  Implementations that do not calculate a receiver-side estimate MUST leave this undefined.
                   Additionally, the value should be undefined for candidate pairs that were never used.
                   For pairs in use, the estimate is normally no lower than the bitrate for
-                  the packets sent at <dfn>lastPacketReceivedTimestamp</dfn>, but might be higher.
+                  the packets received at <code>lastPacketReceivedTimestamp</code>, but might be higher.
                   For candidate pairs that are not currently in use but were used before,
-                  implementations can use the last calculated estimate provided that no further
-                  packets are received.
+                  implementations MUST return undefined.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1735,6 +1735,8 @@ enum RTCStatsType {
              boolean                       readable;
              unsigned long long            bytesSent;
              unsigned long long            bytesReceived;
+             DOMHighResTimeStamp           lastPacketSentTimestamp;
+             DOMHighResTimeStamp           lastPacketReceivedTimestamp;
              double                        totalRoundTripTime;
              double                        currentRoundTripTime;
              double                        availableOutgoingBitrate;
@@ -1853,6 +1855,28 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
+                <dfn><code>lastPacketSentTimestamp</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the timestamp at which the last packet
+                  was sent on this particular candidate pair.
+                  It is of the type <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]].
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>lastPacketReceivedTimestamp</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the timestamp at which the last packet
+                  was received on this particular candidate pair.
+                  It is of the type <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]].
+                </p>
+              </dd>
+              <dt>
                 <dfn><code>totalRoundTripTime</code></dfn> of type <span class=
                 "idlMemberType"><a>double</a></span>
               </dt>
@@ -1889,6 +1913,15 @@ enum RTCStatsType {
                   or UDP. It is similar to the TIAS defined in [[!RFC3890]], i.e., it is measured
                   in bits per second and the bitrate is calculated over a 1 second window.
                 </p>
+                <p>
+                  Implementations that do not calculate a sender-side estimate should leave this undefined.
+                  Additionally, the value should be undefined for candidate pairs that were never used.
+                  For pairs in use, the estimate is normally no lower than the bitrate for
+                  the packets sent at <dfn>lastPacketSentTimestamp</dfn>, but might be higher.
+                  For candidate pairs that are not currently in use but were used before,
+                  implementations can use the last calculated estimate provided that no further
+                  packets are sent.
+                </p>
               </dd>
               <dt>
                 <dfn><code>availableIncomingBitrate</code></dfn> of type <span class=
@@ -1901,6 +1934,15 @@ enum RTCStatsType {
                   measurement does not count the size of the IP or other transport layers like TCP
                   or UDP. It is similar to the TIAS defined in [[!RFC3890]], i.e., it is measured
                   in bits per second and the bitrate is calculated over a 1 second window.
+                </p>
+                <p>
+                  Implementations that do not calculate a receiver-side estimate should leave this undefined.
+                  Additionally, the value should be undefined for candidate pairs that were never used.
+                  For pairs in use, the estimate is normally no lower than the bitrate for
+                  the packets sent at <dfn>lastPacketReceivedTimestamp</dfn>, but might be higher.
+                  For candidate pairs that are not currently in use but were used before,
+                  implementations can use the last calculated estimate provided that no further
+                  packets are sent.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1942,7 +1942,7 @@ enum RTCStatsType {
                   the packets sent at <dfn>lastPacketReceivedTimestamp</dfn>, but might be higher.
                   For candidate pairs that are not currently in use but were used before,
                   implementations can use the last calculated estimate provided that no further
-                  packets are sent.
+                  packets are received.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
corresponds to issues reported in #86, #97, and #112. related to outgoing and incoming bitrate estimates on a candidate pair.

Tries to undo the git rebase hassle in #170.