### PR TITLE
Change log, and make tidy

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -833,8 +833,8 @@ enum RTCStatsType {
                   Round trip time is present only if <code>isRemote</code> is <code>true</code>.
                   Estimated round trip time for this SSRC based on the RTCP timestamps in the RTCP
                   Receiver Report (RR) and measured in seconds. Calculated as defined in section
-                  6.4.1. of [[!RFC3550]]. If no RTCP Receiver Report is received with a DLSR
-                  value other than 0, the round trip time is left undefined.
+                  6.4.1. of [[!RFC3550]]. If no RTCP Receiver Report is received with a DLSR value
+                  other than 0, the round trip time is left undefined.
                 </p>
               </dd>
               <dt>
@@ -1884,8 +1884,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the timestamp at which the last packet
-                  was sent on this particular candidate pair.
+                  Represents the timestamp at which the last packet was sent on this particular
+                  candidate pair.
                 </p>
               </dd>
               <dt>
@@ -1894,8 +1894,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the timestamp at which the last packet
-                  was received on this particular candidate pair.
+                  Represents the timestamp at which the last packet was received on this particular
+                  candidate pair.
                 </p>
               </dd>
               <dt>
@@ -1936,12 +1936,12 @@ enum RTCStatsType {
                   in bits per second and the bitrate is calculated over a 1 second window.
                 </p>
                 <p>
-                  Implementations that do not calculate a sender-side estimate MUST leave this undefined.
-                  Additionally, the value MUST be undefined for candidate pairs that were never used.
-                  For pairs in use, the estimate is normally no lower than the bitrate for
-                  the packets sent at <code>lastPacketSentTimestamp</code>, but might be higher.
-                  For candidate pairs that are not currently in use but were used before,
-                  implementations MUST return undefined.
+                  Implementations that do not calculate a sender-side estimate MUST leave this
+                  undefined. Additionally, the value MUST be undefined for candidate pairs that
+                  were never used. For pairs in use, the estimate is normally no lower than the
+                  bitrate for the packets sent at <code>lastPacketSentTimestamp</code>, but might
+                  be higher. For candidate pairs that are not currently in use but were used
+                  before, implementations MUST return undefined.
                 </p>
               </dd>
               <dt>
@@ -1957,12 +1957,12 @@ enum RTCStatsType {
                   in bits per second and the bitrate is calculated over a 1 second window.
                 </p>
                 <p>
-                  Implementations that do not calculate a receiver-side estimate MUST leave this undefined.
-                  Additionally, the value should be undefined for candidate pairs that were never used.
-                  For pairs in use, the estimate is normally no lower than the bitrate for
-                  the packets received at <code>lastPacketReceivedTimestamp</code>, but might be higher.
-                  For candidate pairs that are not currently in use but were used before,
-                  implementations MUST return undefined.
+                  Implementations that do not calculate a receiver-side estimate MUST leave this
+                  undefined. Additionally, the value should be undefined for candidate pairs that
+                  were never used. For pairs in use, the estimate is normally no lower than the
+                  bitrate for the packets received at <code>lastPacketReceivedTimestamp</code>, but
+                  might be higher. For candidate pairs that are not currently in use but were used
+                  before, implementations MUST return undefined.
                 </p>
               </dd>
               <dt>
@@ -2315,7 +2315,7 @@ function logError(error) {
       </p>
       <section id="since-14-dec-2016*">
         <h3>
-          Changes e 14 Dec 2016
+          Changes between 14 Dec 2016 and 30 Mar 2017
         </h3>
         <ul>
           <li>[#102] certificate stats: describe issuerCertificateId
@@ -2367,6 +2367,10 @@ function logError(error) {
           <li>[#176] Add link from datachannel to transport
           </li>
           <li>[#181] Add section on obsoleted stats
+          </li>
+          <li>[#182] Bandwidth estimations again
+          </li>
+          <li>[#188] RTT undefined when no RTCP RR
           </li>
         </ul>
       </section>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -642,7 +642,7 @@ enum RTCStatsType {
                 <p>
                   The definition of QP value depends on the <a>codec</a>; for VP8, the QP value is
                   the value carried in the frame header as the syntax element "y_ac_qi", and
-                  defined in [[RFC6386]] section 19.2. Its range is 0..127.
+                  defined in [[RFC6386]] section 19.2. Its range is 0..127. 
                   <!-- Need appropriate references for VP9 and H.264 -->
                 </p>
                 <p>
@@ -991,16 +991,13 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Present if <code>isRemote</code> is <code>true</code>,
-                  <code>remoteTimestamp</code>, of type
-                  <code>DOMHighResTimeStamp</code> [[!HIGHRES-TIME]],
-                  represents the remote timestamp at which these statistics
-                  were sent by the remote endpoint. This differs from
-                  <code>timestamp</code>, which represents the time at which
-                  the statistics were generated or received by the local
-                  endpoint. The <code>remoteTimestamp</code>, if present, is
-                  derived from the NTP timestamp in an RTCP SR packet, which
-                  reflects the remote endpoint's clock. That clock may not be
-                  synchronized with the local clock. The time is relative to
+                  <code>remoteTimestamp</code>, of type <code>DOMHighResTimeStamp</code>
+                  [[!HIGHRES-TIME]], represents the remote timestamp at which these statistics were
+                  sent by the remote endpoint. This differs from <code>timestamp</code>, which
+                  represents the time at which the statistics were generated or received by the
+                  local endpoint. The <code>remoteTimestamp</code>, if present, is derived from the
+                  NTP timestamp in an RTCP SR packet, which reflects the remote endpoint's clock.
+                  That clock may not be synchronized with the local clock. The time is relative to
                   the UNIX epoch (Jan 1, 1970, UTC).
                 </p>
               </dd>
@@ -2304,7 +2301,7 @@ function logError(error) {
       </h3>
       <p>
         Some stats identifiers may expose personally identifiable information, for example the IP
-        addresses of the participating endpoints when a TURN relay is not used.
+        addresses of the participating endpoints when a TURN relay is not used. 
         <!-- TODO: add guidance on how to not expose this information? -->
       </p>
     </section>
@@ -2316,6 +2313,63 @@ function logError(error) {
         This section will be removed before publication. The entries are in reverse chronological
         order.
       </p>
+      <section id="since-14-dec-2016*">
+        <h3>
+          Changes e 14 Dec 2016
+        </h3>
+        <ul>
+          <li>[#102] certificate stats: describe issuerCertificateId
+          </li>
+          <li>[#114] Minor clarification regarding stats object lifetime
+          </li>
+          <li>[#157] Change type of RTCRTPStreamStats.ssrc from string to unsigled long
+          </li>
+          <li>[#149] Remove references saying "defines an API"
+          </li>
+          <li>[#148] Explanation for "remoteSource"
+          </li>
+          <li>[#156] frameWidth/frameHeight: use last decoded value
+          </li>
+          <li>[#123] Explain "sum and count" design paradigm
+          </li>
+          <li>[#126] Fix RTCStatsType for "stream"
+          </li>
+          <li>[#127] Added "kind" to RTCMediaStreamTrackStats
+          </li>
+          <li>[#129] Remove ssrcids field
+          </li>
+          <li>[#128] Define audio level rigidly
+          </li>
+          <li>[#122] Replace RTCTransportStats.active with .dtlsState
+          </li>
+          <li>[#125] Added more datachannel counters, with definitions
+          </li>
+          <li>[#142] Rename RTCRtpMediaStreamStats.trackId
+          </li>
+          <li>[#167] Moving roundTripTime from outbound to inbound
+          </li>
+          <li>[#139] Define terminology for "stats object" et al
+          </li>
+          <li>[#169] Fix issues with TURN URL protocol
+          </li>
+          <li>[#168] Align codec types with webrtc-pc
+          </li>
+          <li>[#166] Removed cancelled and renamed inprogress to in-progress
+          </li>
+          <li>[#164] Added remoteTimestamp to RTCRtpStreamTrackStats
+          </li>
+          <li>[#138] Make a RTCMediaStreamTackStats object per track attachment
+          </li>
+          <li>[#165] Remove separation of received consent and connectivity requests
+          </li>
+          <li>[#179] Adds definitions for RTCDataChannelStats members
+          </li>
+          <li>[#176] Add link from datachannel to transport
+          </li>
+          <li>[#181] Add section on obsoleted stats
+          </li>
+        </ul>
+      </section>
       <section id="since-21-sep-2016*">
         <h3>
           Changes since 21 sep 2016


### PR DESCRIPTION
Note that "make tidy" inserts an extra space for reasons unknown.
It is too tedious to remove it by hand, so it's left in.