### PR TITLE
Refactor out isRemote.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -73,8 +73,10 @@
         <li>It MUST support generating statistics for the type RTCOutboundRTPStreamStats, with
         attributes packetsSent, bytesSent.
         </li>
-        <li>For all subclasses of RTCRTPStreamStats, it MUST include ssrc, mediaType,
-        and either remoteId or localId as appropriate.
+        <li>For all subclasses of RTCRTPStreamStats, it MUST include ssrc and mediaType.
+        When stats exist for both sides of a connection, in the form of an
+        inbound-rtp / remote-outbound-rtp pair or an outbound-rtp /
+        remote-inbound-rtp pair, the members remoteId and localId MUST also be present.
         </li>
         <li>It MAY support generating other stats.
         </li>
@@ -408,7 +410,7 @@ enum RTCStatsType {
               corresponding to an outbound stream that is currently sent with
               this <code>RTCPeerConnection</code> object. It is measured at the
               remote endpoint and reported in an RTCP RR/XR. It is accessed by
-              the <code><a>RTCInboundRTPStreamStats</a></code>.
+              the <code><a>RTCRemoteInboundRTPStreamStats</a></code>.
             </p>
           </dd>
           <dt>
@@ -420,7 +422,7 @@ enum RTCStatsType {
               corresponding to an inbound stream that is currently received with
               this <code>RTCPeerConnection</code> object. It is measured at the
               remote endpoint and reported in an RTCP SR. It is accessed by the
-              <code><a>RTCOutboundRTPStreamStats</a></code>.
+              <code><a>RTCRemoteOutboundRTPStreamStats</a></code>.
             </p>
           </dd>
           <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -73,8 +73,8 @@
         <li>It MUST support generating statistics for the type RTCOutboundRTPStreamStats, with
         attributes packetsSent, bytesSent.
         </li>
-        <li>For all subclasses of RTCRTPStreamStats, it MUST include ssrc, associateStatsId,
-        mediaType.
+        <li>For all subclasses of RTCRTPStreamStats, it MUST include ssrc, remoteId,
+        localId, mediaType.
         </li>
         <li>It MAY support generating other stats.
         </li>
@@ -521,7 +521,6 @@ enum RTCStatsType {
         <div>
           <pre class="idl">dictionary RTCRTPStreamStats : RTCStats {
              unsigned long       ssrc;
-             DOMString           associateStatsId;
              DOMString           mediaType;
              DOMString           trackId;
              DOMString           transportId;
@@ -546,16 +545,6 @@ enum RTCStatsType {
                 <p>
                   The 32-bit unsigned integer value per [[RFC3550]] used to identify the source of
                   the stream of RTP packets that this stats object concerns.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>associateStatsId</code></dfn> of type <span class=
-                "idlMemberType"><a>DOMString</a></span>
-              </dt>
-              <dd>
-                <p>
-                  The <code>associateStatsId</code> is used for looking up the corresponding
-                  (local/remote) <code><a>RTCStats</a></code> object for a given SSRC.
                 </p>
               </dd>
               <dt>
@@ -957,6 +946,7 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCInboundRTPStreamStats : RTCReceivedRTPStreamStats {
+             DOMString          remoteId;
              unsigned long      framesDecoded;
 };</pre>
           <section>
@@ -965,6 +955,17 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCInboundRTPStreamStats" data-dfn-for="RTCInboundRTPStreamStats"
             class="dictionary-members">
+              <dt>
+                <dfn><code>remoteId</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The <code>remoteId</code> is used for looking up the remote
+                  <code><a>RTCRemoteOutboundRTPStreamStats</a></code> object for
+                  a given SSRC.
+                </p>
+              </dd>
               <dt>
                 <dfn><code>framesDecoded</code></dfn>
               </dt>
@@ -990,6 +991,7 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCRemoteInboundRTPStreamStats : RTCReceivedRTPStreamStats {
+             DOMString          localId;
              double             roundTripTime;
 };</pre>
           <section>
@@ -998,6 +1000,17 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCRemoteInboundRTPStreamStats" data-dfn-for="RTCRemoteInboundRTPStreamStats"
             class="dictionary-members">
+              <dt>
+                <dfn><code>localId</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The <code>localId</code> is used for looking up the local
+                  <code><a>RTCOutboundRTPStreamStats</a></code> object for a
+                  given SSRC.
+                </p>
+              </dd>
               <dt>
                 <dfn><code>roundTripTime</code></dfn> of type <span class=
                 "idlMemberType"><a>double</a></span>
@@ -1063,6 +1076,7 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCOutboundRTPStreamStats : RTCSentRTPStreamStats {
+             DOMString          remoteId;
              double             targetBitrate;
              unsigned long      framesEncoded;
              double             totalEncodeTime;
@@ -1073,6 +1087,17 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCOutboundRTPStreamStats" data-dfn-for="RTCOutboundRTPStreamStats"
             class="dictionary-members">
+              <dt>
+                <dfn><code>remoteId</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The <code>remoteId</code> is used for looking up the remote
+                  <code><a>RTCRemoteInboundRTPStreamStats</a></code> object for
+                  a given SSRC.
+                </p>
+              </dd>
               <dt>
                 <dfn><code>targetBitrate</code></dfn> of type <span class=
                 "idlMemberType"><a>double</a></span>
@@ -1126,6 +1151,7 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCRemoteOutboundRTPStreamStats : RTCSentRTPStreamStats {
+             DOMString           localId;
              DOMHighResTimeStamp remoteTimestamp;
 };</pre>
           <section>
@@ -1134,6 +1160,17 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCRemoteOutboundRTPStreamStats" data-dfn-for="RTCRemoteOutboundRTPStreamStats"
             class="dictionary-members">
+              <dt>
+                <dfn><code>localId</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The <code>localId</code> is used for looking up the local
+                  <code><a>RTCInboundRTPStreamStats</a></code> object for a
+                  given SSRC.
+                </p>
+              </dd>
               <dt>
                 <dfn><code>remoteTimestamp</code></dfn> of type <span class=
                 "idlMemberType"><a>DOMHighResTimeStamp</a></span>
@@ -2335,13 +2372,13 @@ stats [
       ssrc=1234
       id=foobar
       type="outbound-rtp"
-      associateStatsId=barfoo
+      remoteId=barfoo
   },
   dictionary (of type RTCRemoteInboundRTPStreamStats) {
       ssrc=1234
       id=barfoo
       type="remote-inbound-rtp"
-      associateStatsId=foobar
+      localId=foobar
   }
 ]
           </pre>
@@ -2386,8 +2423,8 @@ function processStats() {
         let base = baselineReport.get(now.id);
 
         if (base) {
-            remoteNow = currentReport.get(now.associateStatsId);
-            remoteBase = baselineReport.get(base.associateStatsId);
+            remoteNow = currentReport[now.remoteId];
+            remoteBase = baselineReport[base.remoteId];
 
             var packetsSent = now.packetsSent - base.packetsSent;
             var packetsReceived = remoteNow.packetsReceived - remoteBase.packetsReceived;

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -938,7 +938,7 @@ enum RTCStatsType {
       </section>
       <section id="inboundrtpstats-dict*">
         <h3>
-          <dfn>RTCInboundRTPStreamStats</dfn> dictionary
+          RTCInboundRTPStreamStats dictionary
         </h3>
         <p>
           The <dfn>RTCInboundRTPStreamStats</dfn> dictionary represents the measurement metrics for
@@ -982,7 +982,7 @@ enum RTCStatsType {
       </section>
       <section id="remoteinboundrtpstats-dict*">
         <h3>
-          <dfn>RTCRemoteInboundRTPStreamStats</dfn> dictionary
+          RTCRemoteInboundRTPStreamStats dictionary
         </h3>
         <p>
           The <dfn>RTCRemoteInboundRTPStreamStats</dfn> dictionary represents
@@ -1068,7 +1068,7 @@ enum RTCStatsType {
       </section>
       <section id="outboundrtpstats-dict*">
         <h3>
-          <dfn>RTCOutboundRTPStreamStats</dfn> dictionary
+          RTCOutboundRTPStreamStats dictionary
         </h3>
         <p>
           The <dfn>RTCOutboundRTPStreamStats</dfn> dictionary represents the
@@ -1142,7 +1142,7 @@ enum RTCStatsType {
       </section>
       <section id="remoteoutboundrtpstats-dict*">
         <h3>
-          <dfn>RTCRemoteOutboundRTPStreamStats</dfn> dictionary
+          RTCRemoteOutboundRTPStreamStats dictionary
         </h3>
         <p>
           The <dfn>RTCRemoteOutboundRTPStreamStats</dfn> dictionary represents

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -963,7 +963,7 @@ enum RTCStatsType {
                 <p>
                   The <code>remoteId</code> is used for looking up the remote
                   <code><a>RTCRemoteOutboundRTPStreamStats</a></code> object for
-                  a given SSRC.
+                  the same SSRC.
                 </p>
               </dd>
               <dt>
@@ -1007,8 +1007,8 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The <code>localId</code> is used for looking up the local
-                  <code><a>RTCOutboundRTPStreamStats</a></code> object for a
-                  given SSRC.
+                  <code><a>RTCOutboundRTPStreamStats</a></code> object for the
+                  same SSRC.
                 </p>
               </dd>
               <dt>
@@ -1095,7 +1095,7 @@ enum RTCStatsType {
                 <p>
                   The <code>remoteId</code> is used for looking up the remote
                   <code><a>RTCRemoteInboundRTPStreamStats</a></code> object for
-                  a given SSRC.
+                  the same SSRC.
                 </p>
               </dd>
               <dt>
@@ -1167,8 +1167,8 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The <code>localId</code> is used for looking up the local
-                  <code><a>RTCInboundRTPStreamStats</a></code> object for a
-                  given SSRC.
+                  <code><a>RTCInboundRTPStreamStats</a></code> object for the
+                  same SSRC.
                 </p>
               </dd>
               <dt>
@@ -2358,31 +2358,6 @@ enum RTCStatsType {
       <h2>
         Examples
       </h2>
-      <section>
-        <h4>
-          Example of association of local and remote statistics
-        </h4>
-        <p>
-          The following example code shows the association of remote statistics with local
-          statistics in a <code>RTCStats</code> dictionary.
-        </p>
-        <pre class="example highlight">
-stats [
-   dictionary (of type RTCOutboundRTPStreamStats) {
-      ssrc=1234
-      id=foobar
-      type="outbound-rtp"
-      remoteId=barfoo
-  },
-  dictionary (of type RTCRemoteInboundRTPStreamStats) {
-      ssrc=1234
-      id=barfoo
-      type="remote-inbound-rtp"
-      localId=foobar
-  }
-]
-          </pre>
-      </section>
       <section>
         <h3>
           Example of a stats application

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -73,8 +73,8 @@
         <li>It MUST support generating statistics for the type RTCOutboundRTPStreamStats, with
         attributes packetsSent, bytesSent.
         </li>
-        <li>For all subclasses of RTCRtpStreamStats, it MUST include ssrc, associateStatsId,
-        isRemote, mediaType.
+        <li>For all subclasses of RTCRTPStreamStats, it MUST include ssrc, associateStatsId,
+        mediaType.
         </li>
         <li>It MAY support generating other stats.
         </li>
@@ -522,7 +522,6 @@ enum RTCStatsType {
           <pre class="idl">dictionary RTCRTPStreamStats : RTCStats {
              unsigned long       ssrc;
              DOMString           associateStatsId;
-             boolean             isRemote = false;
              DOMString           mediaType;
              DOMString           trackId;
              DOMString           transportId;
@@ -557,17 +556,6 @@ enum RTCStatsType {
                 <p>
                   The <code>associateStatsId</code> is used for looking up the corresponding
                   (local/remote) <code><a>RTCStats</a></code> object for a given SSRC.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>isRemote</code></dfn> of type <span class=
-                "idlMemberType"><a>boolean</a></span>, defaulting to <code>false</code>
-              </dt>
-              <dd>
-                <p>
-                  <code>false</code> indicates that the statistics are measured locally, while
-                  <code>true</code> indicates that the measurements were done at the remote
-                  endpoint and reported in an RTCP RR/XR.
                 </p>
               </dd>
               <dt>
@@ -2346,15 +2334,13 @@ stats [
    dictionary (of type RTCOutboundRTPStreamStats) {
       ssrc=1234
       id=foobar
-      type=outboundrtp
-      isRemote=false
+      type="outbound-rtp"
       associateStatsId=barfoo
   },
   dictionary (of type RTCRemoteInboundRTPStreamStats) {
       ssrc=1234
       id=barfoo
-      type=inboundrtp
-      isRemote=true
+      type="remote-inbound-rtp"
       associateStatsId=foobar
   }
 ]

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -73,8 +73,8 @@
         <li>It MUST support generating statistics for the type RTCOutboundRTPStreamStats, with
         attributes packetsSent, bytesSent.
         </li>
-        <li>For all subclasses of RTCRTPStreamStats, it MUST include ssrc, remoteId,
-        localId, mediaType.
+        <li>For all subclasses of RTCRTPStreamStats, it MUST include ssrc, mediaType,
+        and either remoteId or localId as appropriate.
         </li>
         <li>It MAY support generating other stats.
         </li>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -352,6 +352,8 @@ enum RTCStatsType {
 "codec",
 "inbound-rtp",
 "outbound-rtp",
+"remote-inbound-rtp",
+"remote-outbound-rtp",
 "peer-connection",
 "data-channel",
 "stream",
@@ -394,6 +396,30 @@ enum RTCStatsType {
             <p>
               Statistics for an outbound RTP stream that is currently sent with this
               <code>RTCPeerConnection</code> object. It is accessed by the
+              <code><a>RTCOutboundRTPStreamStats</a></code>.
+            </p>
+          </dd>
+          <dt>
+            <dfn><code>remote-inbound-rtp</code></dfn>
+          </dt>
+          <dd>
+            <p>
+              Statistics for the remote endpoint's inbound RTP stream
+              corresponding to an outbound stream that is currently sent with
+              this <code>RTCPeerConnection</code> object. It is measured at the
+              remote endpoint and reported in an RTCP RR/XR. It is accessed by
+              the <code><a>RTCInboundRTPStreamStats</a></code>.
+            </p>
+          </dd>
+          <dt>
+            <dfn><code>remote-outbound-rtp</code></dfn>
+          </dt>
+          <dd>
+            <p>
+              Statistics for the remote endpoint's outbound RTP stream
+              corresponding to an inbound stream that is currently received with
+              this <code>RTCPeerConnection</code> object. It is measured at the
+              remote endpoint and reported in an RTCP SR. It is accessed by the
               <code><a>RTCOutboundRTPStreamStats</a></code>.
             </p>
           </dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -409,7 +409,8 @@ enum RTCStatsType {
               Statistics for the remote endpoint's inbound RTP stream
               corresponding to an outbound stream that is currently sent with
               this <code>RTCPeerConnection</code> object. It is measured at the
-              remote endpoint and reported in an RTCP RR/XR. It is accessed by
+              remote endpoint and reported in an RTCP Receiver Report (RR) or
+              RTCP Extended Report (XR). It is accessed by
               the <code><a>RTCRemoteInboundRTPStreamStats</a></code>.
             </p>
           </dd>
@@ -421,7 +422,8 @@ enum RTCStatsType {
               Statistics for the remote endpoint's outbound RTP stream
               corresponding to an inbound stream that is currently received with
               this <code>RTCPeerConnection</code> object. It is measured at the
-              remote endpoint and reported in an RTCP SR. It is accessed by the
+              remote endpoint and reported in an RTCP Sender Report (SR). It is
+              accessed by the
               <code><a>RTCRemoteOutboundRTPStreamStats</a></code>.
             </p>
           </dd>
@@ -1184,9 +1186,9 @@ enum RTCStatsType {
                   sent by the remote endpoint. This differs from <code>timestamp</code>, which
                   represents the time at which the statistics were generated or received by the
                   local endpoint. The <code>remoteTimestamp</code>, if present, is derived from the
-                  NTP timestamp in an RTCP SR packet, which reflects the remote endpoint's clock.
-                  That clock may not be synchronized with the local clock. The time is relative to
-                  the UNIX epoch (Jan 1, 1970, UTC).
+                  NTP timestamp in an RTCP Sender Report (SR) packet, which reflects the remote
+                  endpoint's clock. That clock may not be synchronized with the local clock. The
+                  time is relative to the UNIX epoch (Jan 1, 1970, UTC).
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -766,22 +766,17 @@ enum RTCStatsType {
           </section>
         </div>
       </section>
-      <section id="inboundrtpstats-dict*">
+      <section id="receivedrtpstats-dict*">
         <h3>
-          RTCInboundRTPStreamStats dictionary
+          <dfn>RTCReceivedRTPStreamStats</dfn> dictionary
         </h3>
-        <p>
-          The <dfn>RTCInboundRTPStreamStats</dfn> dictionary represents the measurement metrics for
-          the incoming RTP media stream.
-        </p>
         <div>
-          <pre class="idl">dictionary RTCInboundRTPStreamStats : RTCRTPStreamStats {
+          <pre class="idl">dictionary RTCReceivedRTPStreamStats : RTCRTPStreamStats {
              unsigned long      packetsReceived;
              unsigned long long bytesReceived;
              unsigned long      packetsLost;
              double             jitter;
              double             fractionLost;
-             double             roundTripTime;
              unsigned long      packetsDiscarded;
              unsigned long      packetsRepaired;
              unsigned long      burstPacketsLost;
@@ -792,13 +787,12 @@ enum RTCStatsType {
              double             burstDiscardRate;
              double             gapLossRate;
              double             gapDiscardRate;
-             unsigned long      framesDecoded;
 };</pre>
           <section>
             <h2>
-              Dictionary <a class="idlType">RTCInboundRTPStreamStats</a> Members
+              Dictionary <a class="idlType">RTCReceivedRTPStreamStats</a> Members
             </h2>
-            <dl data-link-for="RTCInboundRTPStreamStats" data-dfn-for="RTCInboundRTPStreamStats"
+            <dl data-link-for="RTCReceivedRTPStreamStats" data-dfn-for="RTCReceivedRTPStreamStats"
             class="dictionary-members">
               <dt>
                 <dfn><code>packetsReceived</code></dfn> of type <span class=
@@ -848,19 +842,6 @@ enum RTCStatsType {
                 <p>
                   The fraction packet loss reported for this SSRC. Calculated as defined in
                   [[!RFC3550]] section 6.4.1 and Appendix A.3.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>roundTripTime</code></dfn> of type <span class=
-                "idlMemberType"><a>double</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Round trip time is present only if <code>isRemote</code> is <code>true</code>.
-                  Estimated round trip time for this SSRC based on the RTCP timestamps in the RTCP
-                  Receiver Report (RR) and measured in seconds. Calculated as defined in section
-                  6.4.1. of [[!RFC3550]]. If no RTCP Receiver Report is received with a DLSR value
-                  other than 0, the round trip time is left undefined.
                 </p>
               </dd>
               <dt>
@@ -974,6 +955,28 @@ enum RTCStatsType {
                   [[!RFC7004]], however, the actual value is reported without multiplying by 32768.
                 </p>
               </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="inboundrtpstats-dict*">
+        <h3>
+          <dfn>RTCInboundRTPStreamStats</dfn> dictionary
+        </h3>
+        <p>
+          The <dfn>RTCInboundRTPStreamStats</dfn> dictionary represents the measurement metrics for
+          the incoming RTP media stream.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCInboundRTPStreamStats : RTCReceivedRTPStreamStats {
+             unsigned long      framesDecoded;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCInboundRTPStreamStats</a> Members
+            </h2>
+            <dl data-link-for="RTCInboundRTPStreamStats" data-dfn-for="RTCInboundRTPStreamStats"
+            class="dictionary-members">
               <dt>
                 <dfn><code>framesDecoded</code></dfn>
               </dt>
@@ -988,46 +991,56 @@ enum RTCStatsType {
           </section>
         </div>
       </section>
-      <section id="outboundrtpstats-dict*">
+      <section id="remoteinboundrtpstats-dict*">
         <h3>
-          RTCOutboundRTPStreamStats dictionary
+          <dfn>RTCRemoteInboundRTPStreamStats</dfn> dictionary
         </h3>
         <p>
-          <dfn>RTCOutboundRTPStreamStats</dfn> dictionary represents the measurement metrics for
-          the outgoing RTP stream.
+          The <dfn>RTCRemoteInboundRTPStreamStats</dfn> dictionary represents
+          the remote endpoint's measurement metrics for its incoming RTP stream
+          (our outgoing RTP stream).
         </p>
         <div>
-          <pre class="idl">dictionary RTCOutboundRTPStreamStats : RTCRTPStreamStats {
-             DOMHighResTimeStamp remoteTimestamp;
-             unsigned long      packetsSent;
-             unsigned long long bytesSent;
-             double             targetBitrate;
-             unsigned long      framesEncoded;
-             double             totalEncodeTime;
+          <pre class="idl">dictionary RTCRemoteInboundRTPStreamStats : RTCReceivedRTPStreamStats {
+             double             roundTripTime;
 };</pre>
           <section>
             <h2>
-              Dictionary <a class="idlType">RTCOutboundRTPStreamStats</a> Members
+              Dictionary <a class="idlType">RTCRemoteInboundRTPStreamStats</a> Members
             </h2>
-            <dl data-link-for="RTCOutboundRTPStreamStats" data-dfn-for="RTCOutboundRTPStreamStats"
+            <dl data-link-for="RTCRemoteInboundRTPStreamStats" data-dfn-for="RTCRemoteInboundRTPStreamStats"
             class="dictionary-members">
               <dt>
-                <dfn><code>remoteTimestamp</code></dfn> of type <span class=
-                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
+                <dfn><code>roundTripTime</code></dfn> of type <span class=
+                "idlMemberType"><a>double</a></span>
               </dt>
               <dd>
                 <p>
-                  Present if <code>isRemote</code> is <code>true</code>,
-                  <code>remoteTimestamp</code>, of type <code>DOMHighResTimeStamp</code>
-                  [[!HIGHRES-TIME]], represents the remote timestamp at which these statistics were
-                  sent by the remote endpoint. This differs from <code>timestamp</code>, which
-                  represents the time at which the statistics were generated or received by the
-                  local endpoint. The <code>remoteTimestamp</code>, if present, is derived from the
-                  NTP timestamp in an RTCP SR packet, which reflects the remote endpoint's clock.
-                  That clock may not be synchronized with the local clock. The time is relative to
-                  the UNIX epoch (Jan 1, 1970, UTC).
+                  Estimated round trip time for this SSRC based on the RTCP timestamps in the RTCP
+                  Receiver Report (RR) and measured in seconds. Calculated as defined in section
+                  6.4.1. of [[!RFC3550]]. If no RTCP Receiver Report is received with a DLSR value
+                  other than 0, the round trip time is left undefined.
                 </p>
               </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="sentrtpstats-dict*">
+        <h3>
+          <dfn>RTCSentRTPStreamStats</dfn> dictionary
+        </h3>
+        <div>
+          <pre class="idl">dictionary RTCSentRTPStreamStats : RTCRTPStreamStats {
+             unsigned long      packetsSent;
+             unsigned long long bytesSent;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCSentRTPStreamStats</a> Members
+            </h2>
+            <dl data-link-for="RTCSentRTPStreamStats" data-dfn-for="RTCSentRTPStreamStats"
+            class="dictionary-members">
               <dt>
                 <dfn><code>packetsSent</code></dfn> of type <span class="idlMemberType"><a>unsigned
                 long</a></span>
@@ -1048,6 +1061,30 @@ enum RTCStatsType {
                   section 6.4.1.
                 </p>
               </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="outboundrtpstats-dict*">
+        <h3>
+          <dfn>RTCOutboundRTPStreamStats</dfn> dictionary
+        </h3>
+        <p>
+          The <dfn>RTCOutboundRTPStreamStats</dfn> dictionary represents the
+          measurement metrics for the outgoing RTP stream.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCOutboundRTPStreamStats : RTCSentRTPStreamStats {
+             double             targetBitrate;
+             unsigned long      framesEncoded;
+             double             totalEncodeTime;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCOutboundRTPStreamStats</a> Members
+            </h2>
+            <dl data-link-for="RTCOutboundRTPStreamStats" data-dfn-for="RTCOutboundRTPStreamStats"
+            class="dictionary-members">
               <dt>
                 <dfn><code>targetBitrate</code></dfn> of type <span class=
                 "idlMemberType"><a>double</a></span>
@@ -1084,6 +1121,45 @@ enum RTCStatsType {
                   time passed between feeding the encoder a frame and the encoder returning encoded
                   data for that frame. This does not include any additional time it may take to
                   packetize the resulting data.
+                </p>
+              </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="remoteoutboundrtpstats-dict*">
+        <h3>
+          <dfn>RTCRemoteOutboundRTPStreamStats</dfn> dictionary
+        </h3>
+        <p>
+          The <dfn>RTCRemoteOutboundRTPStreamStats</dfn> dictionary represents
+          the remote endpoint's measurement metrics for its outgoing RTP stream
+          (our incoming RTP stream).
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCRemoteOutboundRTPStreamStats : RTCSentRTPStreamStats {
+             DOMHighResTimeStamp remoteTimestamp;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCRemoteOutboundRTPStreamStats</a> Members
+            </h2>
+            <dl data-link-for="RTCRemoteOutboundRTPStreamStats" data-dfn-for="RTCRemoteOutboundRTPStreamStats"
+            class="dictionary-members">
+              <dt>
+                <dfn><code>remoteTimestamp</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
+              </dt>
+              <dd>
+                <p>
+                  <code>remoteTimestamp</code>, of type <code>DOMHighResTimeStamp</code>
+                  [[!HIGHRES-TIME]], represents the remote timestamp at which these statistics were
+                  sent by the remote endpoint. This differs from <code>timestamp</code>, which
+                  represents the time at which the statistics were generated or received by the
+                  local endpoint. The <code>remoteTimestamp</code>, if present, is derived from the
+                  NTP timestamp in an RTCP SR packet, which reflects the remote endpoint's clock.
+                  That clock may not be synchronized with the local clock. The time is relative to
+                  the UNIX epoch (Jan 1, 1970, UTC).
                 </p>
               </dd>
             </dl>
@@ -2267,14 +2343,14 @@ enum RTCStatsType {
         </p>
         <pre class="example highlight">
 stats [
-   dictionary (of type RTPoutboundStatsDictionary) {
+   dictionary (of type RTCOutboundRTPStreamStats) {
       ssrc=1234
       id=foobar
       type=outboundrtp
       isRemote=false
       associateStatsId=barfoo
   },
-  dictionary (of type RTPinboundStatsDictionary) {
+  dictionary (of type RTCRemoteInboundRTPStreamStats) {
       ssrc=1234
       id=barfoo
       type=inboundrtp


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-stats/issues/189.

I found it affirming that this PR revealed to me that the stats examples in both specs have always been broken (they never tested for `!isRemote`)!

@alvestrand PTAL - I'll try to add a slide for tomorrow.