### PR TITLE
Add "packetsFailedDecryption", to count SRTP decryption failures.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -845,6 +845,7 @@ enum RTCStatsType {
              double             jitter;
              double             fractionLost;
              unsigned long      packetsDiscarded;
+             unsigned long      packetsFailedDecryption;
              unsigned long      packetsRepaired;
              unsigned long      burstPacketsLost;
              unsigned long      burstPacketsDiscarded;
@@ -909,6 +910,17 @@ enum RTCStatsType {
                 <p>
                   The fraction packet loss reported for this SSRC. Calculated as defined in
                   [[!RFC3550]] section 6.4.1 and Appendix A.3.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>packetsFailedDecryption</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The cumulative number of RTP packets that failed to be decrypted according
+                  to the procedures in [[!RFC3711]]. These packets are not counted by
+                  <code><a>packetsReceived</a></code> or <code><a>packetsDiscarded</a></code>.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -920,7 +920,7 @@ enum RTCStatsType {
                 <p>
                   The cumulative number of RTP packets that failed to be decrypted according
                   to the procedures in [[!RFC3711]]. These packets are not counted by
-                  <code><a>packetsReceived</a></code> or <code><a>packetsDiscarded</a></code>.
+                  <code><a>packetsDiscarded</a></code>.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Fixes #249.

This could be a useful statistic for diagnosing why calls are failing,
in case an SRTP-related bug is introduced somewhere.