### PR TITLE
Add "sender" and "receiver" stats.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -526,7 +526,11 @@ enum RTCStatsType {
           <dd>
             <p>
               Contains statistics related to a specific MediaStreamTrack and the corresponding
-              media-level metrics. It is accessed by the
+              media-level metrics. It is accessed by one of
+              <code><a>RTCLocalVideoStreamTrackStats</a></code>,
+              <code><a>RTCLocalAudioStreamTrackStats</a></code>,
+              <code><a>RTCRemoteVideoStreamTrackStats</a></code>, or
+              <code><a>RTCRemoteAudioStreamTrackStats</a></code>, all inherited from
               <code><a>RTCMediaStreamTrackStats</a></code>.
             </p>
           </dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1941,11 +1941,10 @@ enum RTCStatsType {
         </p>
         <p>
           If the track is detached from the PeerConnection (via removeTrack or via replaceTrack),
-          it continues to appear, but with the "detached" member set to <code>true</code>.
+          it continues to appear, but with the "objectDeleted" member set to <code>true</code>.
         </p>
         <div>
           <pre class="idl">dictionary RTCLocalVideoStreamTrackStats : RTCVideoSenderStats {
-             boolean             detached;
 };</pre>
           <section>
             <h2>
@@ -1953,16 +1952,6 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCLocalVideoStreamTrackStats" data-dfn-for="RTCLocalVideoStreamTrackStats"
             class="dictionary-members">
-              <dt>
-                <dfn><code>detached</code></dfn> of type <span class=
-                "idlMemberType"><a>boolean</a></span>
-              </dt>
-              <dd>
-                <p>
-                  True if the track has been detached from the PeerConnection object. If true, all
-                  stats reflect their values at the time when the track was detached.
-                </p>
-              </dd>
             </dl>
           </section>
         </div>
@@ -2303,11 +2292,10 @@ enum RTCStatsType {
         </p>
         <p>
           If the track is detached from the PeerConnection (via removeTrack or via replaceTrack),
-          it continues to appear, but with the "detached" member set to <code>true</code>.
+          it continues to appear, but with the "objectDeleted" member set to <code>true</code>.
         </p>
         <div>
           <pre class="idl">dictionary RTCLocalAudioStreamTrackStats : RTCVideoSenderStats {
-             boolean             detached;
 };</pre>
           <section>
             <h2>
@@ -2315,16 +2303,6 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCLocalAudioStreamTrackStats" data-dfn-for="RTCLocalAudioStreamTrackStats"
             class="dictionary-members">
-              <dt>
-                <dfn><code>detached</code></dfn> of type <span class=
-                "idlMemberType"><a>boolean</a></span>
-              </dt>
-              <dd>
-                <p>
-                  True if the track has been detached from the PeerConnection object. If true, all
-                  stats reflect their values at the time when the track was detached.
-                </p>
-              </dd>
             </dl>
           </section>
         </div>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1851,16 +1851,16 @@ enum RTCStatsType {
         </p>
         <p>
           It appears in the stats as soon as it is attached (via addTrack, via addTransceiver, via
-          ReplaceTrack on an RTPSender object).
+          replaceTrack on an RTCRtpSender object).
         </p>
         <p>
-          If a video track is attached twice (via addTransceiver or ReplaceTrack), there will
+          If a video track is attached twice (via addTransceiver or replaceTrack), there will
           be two RTCLocalVideoStreamTrackStats objects, one for each attachment. They will have the same
           "trackIdentifier" attribute, but different "id" attributes.
         </p>
         <p>
           If the track is detached from the PeerConnection (via removeTrack or via replaceTrack),
-          it continues to appear, but with the "detached" member set to True.
+          it continues to appear, but with the "detached" member set to <code>true</code>.
         </p>
         <div>
           <pre class="idl">dictionary RTCLocalVideoStreamTrackStats : RTCVideoStreamTrackStats {
@@ -1921,7 +1921,7 @@ enum RTCStatsType {
           video MediaStreamTrack coming from a PeerConnection object for which one calls getStats.
         </p>
         <p>
-          It appears in the stats as soon as it is created on an RTPReceiver object.
+          It appears in the stats as soon as it is created on an RTCRtpReceiver object.
         </p>
         <div>
           <pre class="idl">dictionary RTCRemoteVideoStreamTrackStats : RTCVideoStreamTrackStats {
@@ -2180,16 +2180,16 @@ enum RTCStatsType {
         </p>
         <p>
           It appears in the stats as soon as it is attached (via addTrack, via addTransceiver, via
-          ReplaceTrack on an RTPSender object).
+          replaceTrack on an RTCRtpSender object).
         </p>
         <p>
-          If an audio track is attached twice (via addTransceiver or ReplaceTrack), there will
+          If an audio track is attached twice (via addTransceiver or replaceTrack), there will
           be two RTCLocalAudioStreamTrackStats objects, one for each attachment. They will have the same
           "trackIdentifier" attribute, but different "id" attributes.
         </p>
         <p>
           If the track is detached from the PeerConnection (via removeTrack or via replaceTrack),
-          it continues to appear, but with the "detached" member set to True.
+          it continues to appear, but with the "detached" member set to <code>true</code>.
         </p>
         <div>
           <pre class="idl">dictionary RTCLocalAudioStreamTrackStats : RTCAudioStreamTrackStats {
@@ -2245,7 +2245,7 @@ enum RTCStatsType {
           audio MediaStreamTrack coming from a PeerConnection object for which one calls getStats.
         </p>
         <p>
-          It appears in the stats as soon as it is created on an RTPReceiver object.
+          It appears in the stats as soon as it is created on an RTCRtpReceiver object.
         </p>
         <div>
           <pre class="idl">dictionary RTCRemoteAudioStreamTrackStats : RTCAudioStreamTrackStats {

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -420,6 +420,8 @@ enum RTCStatsType {
 "data-channel",
 "stream",
 "track",
+"sender",
+"receiver",
 "transport",
 "candidate-pair",
 "local-candidate",
@@ -520,19 +522,39 @@ enum RTCStatsType {
               <code><a>RTCMediaStreamStats</a></code>.
             </p>
           </dd>
-          <dt>
+           <dt>
             <dfn><code>track</code></dfn>
+           </dt>
+           <dd>
+             <p>
+              Contains statistics related to a specific MediaStreamTrack and the corresponding
+              media-level metrics. It is accessed by either
+              <code><a>RTCLocalVideoStreamTrackStats</a></code> or
+              <code><a>RTCLocalAudioStreamTrackStats</a></code>, both inherited from
+              <code><a>RTCMediaStreamTrackStats</a></code>.
+             </p>
+           </dd>
+          <dt>
+            <dfn><code>sender</code></dfn>
           </dt>
           <dd>
             <p>
-              Contains statistics related to a specific MediaStreamTrack and the corresponding
-              media-level metrics. It is accessed by one of
-              <code><a>RTCLocalVideoStreamTrackStats</a></code>,
-              <code><a>RTCLocalAudioStreamTrackStats</a></code>,
-              <code><a>RTCRemoteVideoStreamTrackStats</a></code>, or
-              <code><a>RTCRemoteAudioStreamTrackStats</a></code>, all inherited from
-              <code><a>RTCMediaStreamTrackStats</a></code>.
+              Contains statistics related to a specific RTCRtpSender and the corresponding
+              media-level metrics. It is accessed by the
+              <code><a>RTCAudioSenderStats</a></code> or the <code><a>RTCVideoSenderStats</a></code>
+              depending on <code>kind</code>.
             </p>
+          </dd>
+          <dt>
+            <dfn><code>receiver</code></dfn>
+          </dt>
+          <dd>
+            <p>
+              Contains statistics related to a specific receiver and the corresponding
+              media-level metrics. It is accessed by the
+              <code><a>RTCAudioReceiverStats</a></code> or the <code><a>RTCVideoSenderStats</a></code>
+              depending on <code>kind</code>.
+           </p>
           </dd>
           <dt>
             <dfn><code>transport</code></dfn>
@@ -1715,9 +1737,7 @@ enum RTCStatsType {
         <div>
           <pre class="idl">dictionary RTCMediaStreamTrackStats : RTCStats {
              DOMString           trackIdentifier;
-             boolean             remoteSource;
              boolean             ended;
-             boolean             detached;
              DOMString           kind;
              RTCPriorityType     priority;
 };</pre>
@@ -1751,16 +1771,6 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Reflects the "ended" state of the track.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>detached</code></dfn> of type <span class=
-                "idlMemberType"><a>boolean</a></span>
-              </dt>
-              <dd>
-                <p>
-                  True if the track has been detached from the PeerConnection object. If true, all
-                  stats reflect their values at the time when the track was detached.
                 </p>
               </dd>
               <dt>
@@ -1841,6 +1851,77 @@ enum RTCStatsType {
           </section>
         </div>
       </section>
+      <section id="vsstats-dict*">
+        <h3>
+          <dfn>RTCVideoSenderStats</dfn> dictionary
+        </h3>
+        <p>
+          An RTCVideoSenderStats object represents the stats about one video sender of a
+          PeerConnection object for which one calls getStats.
+        </p>
+        <p>
+          It appears in the stats as soon as the sender is added by either addTrack or
+          addTransceiver, or by media negotiation.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCVideoSenderStats : RTCVideoStreamTrackStats {
+             unsigned long       framesCaptured;
+             unsigned long       framesSent;
+             unsigned long       keyFramesSent;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCVideoSenderStats</a> Members
+            </h2>
+            <dl data-link-for="RTCVideoSenderStats" data-dfn-for="RTCVideoSenderStats"
+            class="dictionary-members">
+              <dt>
+                <dfn><code>framesCaptured</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the total number of frames captured, before encoding,
+                  for this RTCRtpSender (or for this MediaStreamTrack, if
+                  <code>type</code> is <code>"track"</code>).
+                  For example, if <code>type</code> is <code>"sender"</code> and
+                  this sender's track represents a camera, then this is the number
+                  of frames produced by the camera for this track while being sent
+                  by this sender, combined with the number of frames produced by
+                  all tracks previously attached to this sender while being sent by
+                  this sender. Framerates can vary due to hardware limitations or
+                  environmental factors such as lighting conditions.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>framesSent</code></dfn> of type <span class="idlMemberType"><a>unsigned
+                long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the total number of frames sent by this RTCRtpSender
+                  (or for this MediaStreamTrack, if <code>type</code> is
+                  <code>"track"</code>).
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>keyFramesSent</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Only valid for video. It represents the total number of key
+                  frames sent by this RTCRtpSender (or for this MediaStreamTrack,
+                  if <code>type</code> is <code>"track"</code>), such as
+                  Infra-frames in VP8 [[RFC6386]] or I-frames in H.264
+                  [[RFC6184]]. This is a subset of <code>framesSent</code>. <code>framesSent -
+                  keyFramesSent</code> gives you the number of delta frames sent.
+                </p>
+              </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
       <section id="lvststats-dict*">
         <h3>
           <dfn>RTCLocalVideoStreamTrackStats</dfn> dictionary
@@ -1863,10 +1944,8 @@ enum RTCStatsType {
           it continues to appear, but with the "detached" member set to <code>true</code>.
         </p>
         <div>
-          <pre class="idl">dictionary RTCLocalVideoStreamTrackStats : RTCVideoStreamTrackStats {
-             unsigned long       framesCaptured;
-             unsigned long       framesSent;
-             unsigned long       keyFramesSent;
+          <pre class="idl">dictionary RTCLocalVideoStreamTrackStats : RTCVideoSenderStats {
+             boolean             detached;
 };</pre>
           <section>
             <h2>
@@ -1875,37 +1954,13 @@ enum RTCStatsType {
             <dl data-link-for="RTCLocalVideoStreamTrackStats" data-dfn-for="RTCLocalVideoStreamTrackStats"
             class="dictionary-members">
               <dt>
-                <dfn><code>framesCaptured</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long</a></span>
+                <dfn><code>detached</code></dfn> of type <span class=
+                "idlMemberType"><a>boolean</a></span>
               </dt>
               <dd>
                 <p>
-                  Represents the total number of frames captured for
-                  this MediaStreamTrack, before encoding. For example, if this track represents a
-                  camera this is the number of frames produced by the camera for this track, whose
-                  framerate could vary due to hardware limitations or environmental factors such as
-                  lighting conditions.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>framesSent</code></dfn> of type <span class="idlMemberType"><a>unsigned
-                long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of frames sent for this MediaStreamTrack.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>keyFramesSent</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Only valid for video. It represents the total number of key frames sent for this
-                  MediaStreamTrack, such as Infra-frames in VP8 [[RFC6386]] or I-frames in H.264
-                  [[RFC6184]]. This is a subset of <code>framesSent</code>. <code>framesSent -
-                  keyFramesSent</code> gives you the number of delta frames sent.
+                  True if the track has been detached from the PeerConnection object. If true, all
+                  stats reflect their values at the time when the track was detached.
                 </p>
               </dd>
             </dl>
@@ -1914,17 +1969,18 @@ enum RTCStatsType {
       </section>
       <section id="rvststats-dict*">
         <h3>
-          <dfn>RTCRemoteVideoStreamTrackStats</dfn> dictionary
+          <dfn>RTCVideoReceiverStats</dfn> dictionary
         </h3>
         <p>
-          An RTCRemoteVideoStreamTrackStats object represents the stats about one
-          video MediaStreamTrack coming from a PeerConnection object for which one calls getStats.
+          An RTCVideoReceiverStats object represents the stats about one
+          video receiver of a PeerConnection object for which one calls getStats.
         </p>
         <p>
-          It appears in the stats as soon as it is created on an RTCRtpReceiver object.
+          It appears in the stats as soon as the RTCRtpReceiver is added by either addTrack or
+          addTransceiver, or by media negotiation.
         </p>
         <div>
-          <pre class="idl">dictionary RTCRemoteVideoStreamTrackStats : RTCVideoStreamTrackStats {
+          <pre class="idl">dictionary RTCVideoReceiverStats : RTCVideoStreamTrackStats {
              DOMHighResTimeStamp estimatedPlayoutTimestamp;
              double              jitterBufferDelay;
              unsigned long long  jitterBufferEmittedCount;
@@ -1938,9 +1994,9 @@ enum RTCStatsType {
 };</pre>
           <section>
             <h2>
-              Dictionary <a class="idlType">RTCRemoteVideoStreamTrackStats</a> Members
+              Dictionary <a class="idlType">RTCVideoReceiverStats</a> Members
             </h2>
-            <dl data-link-for="RTCRemoteVideoStreamTrackStats" data-dfn-for="RTCRemoteVideoStreamTrackStats"
+            <dl data-link-for="RTCVideoReceiverStats" data-dfn-for="RTCVideoReceiverStats"
             class="dictionary-members">
               <dt>
                 <dfn><code>estimatedPlayoutTimestamp</code></dfn> of type <span class=
@@ -1948,7 +2004,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  This is the estimated playout time of this track.
+                  This is the estimated playout time of this receiver's track.
                   The playout time is the NTP timestamp of the last playable video
                   frame that has a known timestamp (from an RTCP SR packet mapping RTP timestamps to
                   NTP timestamps), extrapolated with the time elapsed since it was ready to be
@@ -1957,7 +2013,7 @@ enum RTCStatsType {
                 </p>
                 <p>
                   This can be useful for estimating how much audio and video is out of sync for two
-                  tracks from the same source, <code>audioTrackStats.estimatedPlayoutTimestamp -
+                  tracks from the same remote source, <code>audioTrackStats.estimatedPlayoutTimestamp -
                   videoTrackStats.estimatedPlayoutTimestamp</code>.
                 </p>
               </dd>
@@ -1991,7 +2047,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the total number of frames received for this MediaStreamTrack.
+                  Represents the total number of frames received for this receiver.
                 </p>
               </dd>
               <dt>
@@ -2014,7 +2070,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the total number of frames correctly decoded for this
-                  MediaStreamTrack, independent of which SSRC it was received from. It is defined
+                  receiver, independent of which SSRC it was received from. It is defined
                   as <code>totalVideoFrames</code> in Section 5 of [[!MEDIA-SOURCE]].
                 </p>
               </dd>
@@ -2025,7 +2081,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The total number of frames dropped predecode or
-                  dropped because the frame missed its display deadline for this MediastreamTrack.
+                  dropped because the frame missed its display deadline for this receiver's track.
                   It is the same definition as <code>droppedVideoFrames</code> in Section 5 of
                   [[!MEDIA-SOURCE]].
                 </p>
@@ -2037,7 +2093,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The total number of corrupted frames that have been
-                  detected for this MediaStreamTrack. It is the same definition as
+                  detected for this receiver. It is the same definition as
                   <code>corruptedVideoFrames</code> in Section 5 of [[!MEDIA-SOURCE]].
                 </p>
               </dd>
@@ -2170,6 +2226,65 @@ enum RTCStatsType {
           </section>
         </div>
       </section>
+      <section id="asstats-dict*">
+        <h3>
+          <dfn>RTCAudioSenderStats</dfn> dictionary
+        </h3>
+        <p>
+          An RTCAudioSenderStats object represents the stats about one audio sender of a
+          PeerConnection object for which one calls getStats.
+        </p>
+        <p>
+          It appears in the stats as soon as the RTCRtpSender is added by either addTrack or
+          addTransceiver, or by media negotiation.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCAudioSenderStats : RTCAudioStreamTrackStats {
+             double              echoReturnLoss;
+             double              echoReturnLossEnhancement;
+             unsigned long long  totalSamplesSent;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCAudioSenderStats</a> Members
+            </h2>
+            <dl data-link-for="RTCAudioSenderStats" data-dfn-for="RTCAudioSenderStats"
+            class="dictionary-members">
+              <dt>
+                <dfn><code>echoReturnLoss</code></dfn> of type <span class=
+                "idlMemberType"><a>double</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Only present while the sender is sending a track sourced from a
+                  microphone where echo cancellation is
+                  applied. Calculated in decibels, as defined in [[!ECHO]] (2012) section 3.14.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>echoReturnLossEnhancement</code></dfn> of type <span class=
+                "idlMemberType"><a>double</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Only present while the sender is sending a track sourced from a
+                  microphone where echo cancellation is
+                  applied. Calculated in decibels, as defined in [[!ECHO]] (2012) section 3.15.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>totalSamplesSent</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The total number of audio samples that have been sent by this sender.
+                </p>
+              </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
       <section id="laststats-dict*">
         <h3>
           <dfn>RTCLocalAudioStreamTrackStats</dfn> dictionary
@@ -2192,10 +2307,8 @@ enum RTCStatsType {
           it continues to appear, but with the "detached" member set to <code>true</code>.
         </p>
         <div>
-          <pre class="idl">dictionary RTCLocalAudioStreamTrackStats : RTCAudioStreamTrackStats {
-             double              echoReturnLoss;
-             double              echoReturnLossEnhancement;
-             unsigned long long  totalSamplesSent;
+          <pre class="idl">dictionary RTCLocalAudioStreamTrackStats : RTCVideoSenderStats {
+             boolean             detached;
 };</pre>
           <section>
             <h2>
@@ -2204,32 +2317,13 @@ enum RTCStatsType {
             <dl data-link-for="RTCLocalAudioStreamTrackStats" data-dfn-for="RTCLocalAudioStreamTrackStats"
             class="dictionary-members">
               <dt>
-                <dfn><code>echoReturnLoss</code></dfn> of type <span class=
-                "idlMemberType"><a>double</a></span>
+                <dfn><code>detached</code></dfn> of type <span class=
+                "idlMemberType"><a>boolean</a></span>
               </dt>
               <dd>
                 <p>
-                  Only present on tracks sourced from a microphone where echo cancellation is
-                  applied. Calculated in decibels, as defined in [[!ECHO]] (2012) section 3.14.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>echoReturnLossEnhancement</code></dfn> of type <span class=
-                "idlMemberType"><a>double</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Only present on tracks sourced from a microphone where echo cancellation is
-                  applied. Calculated in decibels, as defined in [[!ECHO]] (2012) section 3.15.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>totalSamplesSent</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  The total number of audio samples that have been sent for this track.
+                  True if the track has been detached from the PeerConnection object. If true, all
+                  stats reflect their values at the time when the track was detached.
                 </p>
               </dd>
             </dl>
@@ -2238,17 +2332,18 @@ enum RTCStatsType {
       </section>
       <section id="raststats-dict*">
         <h3>
-          <dfn>RTCRemoteAudioStreamTrackStats</dfn> dictionary
+          <dfn>RTCAudioReceiverStats</dfn> dictionary
         </h3>
         <p>
-          An RTCRemoteAudioStreamTrackStats object represents the stats about one
-          audio MediaStreamTrack coming from a PeerConnection object for which one calls getStats.
+          An RTCAudioReceiverStats object represents the stats about one
+          audio receiver of a PeerConnection object for which one calls getStats.
         </p>
         <p>
-          It appears in the stats as soon as it is created on an RTCRtpReceiver object.
+          It appears in the stats as soon as the RTCRtpReceiver is added by either addTrack or
+          addTransceiver, or by media negotiation.
         </p>
         <div>
-          <pre class="idl">dictionary RTCRemoteAudioStreamTrackStats : RTCAudioStreamTrackStats {
+          <pre class="idl">dictionary RTCAudioReceiverStats : RTCAudioStreamTrackStats {
              DOMHighResTimeStamp estimatedPlayoutTimestamp;
              double              jitterBufferDelay;
              unsigned long long  jitterBufferEmittedCount;
@@ -2258,9 +2353,9 @@ enum RTCStatsType {
 };</pre>
           <section>
             <h2>
-              Dictionary <a class="idlType">RTCRemoteAudioStreamTrackStats</a> Members
+              Dictionary <a class="idlType">RTCAudioReceiverStats</a> Members
             </h2>
-            <dl data-link-for="RTCRemoteAudioStreamTrackStats" data-dfn-for="RTCRemoteAudioStreamTrackStats"
+            <dl data-link-for="RTCAudioReceiverStats" data-dfn-for="RTCAudioReceiverStats"
             class="dictionary-members">
               <dt>
                 <dfn><code>estimatedPlayoutTimestamp</code></dfn> of type <span class=
@@ -2268,7 +2363,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  This is the estimated playout time of this track.
+                  This is the estimated playout time of this receiver's track.
                   The playout time is the NTP timestamp of the last playable audio sample
                   that has a known timestamp (from an RTCP SR packet mapping RTP timestamps to
                   NTP timestamps), extrapolated with the time elapsed since it was ready to be
@@ -2312,7 +2407,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The total number of audio samples that have
-                  been received for this track. This includes <a>concealedSamples</a>.
+                  been received by this receiver. This includes <a>concealedSamples</a>.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1846,7 +1846,7 @@ enum RTCStatsType {
           <dfn>RTCLocalVideoStreamTrackStats</dfn> dictionary
         </h3>
         <p>
-          An RTCMLocalVideoStreamTrackStats object represents the stats about one attachment of a
+          An RTCLocalVideoStreamTrackStats object represents the stats about one attachment of a
           video MediaStreamTrack to the PeerConnection object for which one calls getStats.
         </p>
         <p>
@@ -2175,7 +2175,7 @@ enum RTCStatsType {
           <dfn>RTCLocalAudioStreamTrackStats</dfn> dictionary
         </h3>
         <p>
-          An RTCMLocalVideoStreamTrackStats object represents the stats about one attachment of an
+          An RTCLocalAudioStreamTrackStats object represents the stats about one attachment of an
           audio MediaStreamTrack to the PeerConnection object for which one calls getStats.
         </p>
         <p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1820,7 +1820,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the width of the last
-                  processed video frame for this track. Before the first frame is processed this
+                  processed frame for this track. Before the first frame is processed this
                   attribute is missing.
                 </p>
               </dd>
@@ -1831,7 +1831,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the height of the last
-                  processed video frame for this track. Before the first frame is processed this
+                  processed frame for this track. Before the first frame is processed this
                   attribute is missing.
                 </p>
               </dd>
@@ -2023,7 +2023,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  It is the sum of the time, in seconds, each video frame takes from the time it
+                  It is the sum of the time, in seconds, each frame takes from the time it
                   is received and to the time it exits the jitter buffer. This increases upon
                   frames exiting, having completed their time in the buffer (incrementing
                   <code>jitterBufferEmittedCount</code>). The average jitter buffer delay can be
@@ -2037,7 +2037,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The total number of video frames that have come out of the jitter
+                  The total number of frames that have come out of the jitter
                   buffer (increasing <code>jitterBufferDelay</code>).
                 </p>
               </dd>
@@ -2278,7 +2278,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The total number of audio samples that have been sent by this sender.
+                  The total number of samples that have been sent by this sender.
                 </p>
               </dd>
             </dl>
@@ -2364,7 +2364,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   This is the estimated playout time of this receiver's track.
-                  The playout time is the NTP timestamp of the last playable audio sample
+                  The playout time is the NTP timestamp of the last playable sample
                   that has a known timestamp (from an RTCP SR packet mapping RTP timestamps to
                   NTP timestamps), extrapolated with the time elapsed since it was ready to be
                   played out. This is the "current time" of the track in NTP clock time of the
@@ -2382,7 +2382,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  It is the sum of the time, in seconds, each audio sample takes from the time it
+                  It is the sum of the time, in seconds, each sample takes from the time it
                   is received and to the time it exits the jitter buffer. This increases upon
                   samples exiting, having completed their time in the buffer (incrementing
                   <code>jitterBufferEmittedCount</code>). The average jitter buffer delay can be
@@ -2396,7 +2396,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The total number of audio samples that have come out of the jitter
+                  The total number of samples that have come out of the jitter
                   buffer (increasing <code>jitterBufferDelay</code>).
                 </p>
               </dd>
@@ -2406,7 +2406,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The total number of audio samples that have
+                  The total number of samples that have
                   been received by this receiver. This includes <a>concealedSamples</a>.
                 </p>
               </dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1708,23 +1708,6 @@ enum RTCStatsType {
         <h3>
           <dfn>RTCMediaStreamTrackStats</dfn> dictionary
         </h3>
-        <p>
-          An RTCMediaStreamTrackStats object represents the stats about one attachment of a
-          MediaStreamTrack to the PeerConnection object for which one calls getStats.
-        </p>
-        <p>
-          It appears in the stats as soon as it is attached (via addTrack, via addTransceiver, via
-          ReplaceTrack on an RTPSender object, or via being created on an RTPReceiver object).
-        </p>
-        <p>
-          If an outgoing track is attached twice (via addTransceiver or ReplaceTrack), there will
-          be two RTCMediaStreamTrackStats objects, one for each attachment. They will have the same
-          "trackIdentifier" attribute, but different "id" attributes.
-        </p>
-        <p>
-          If the track is detached from the PeerConnection (via removeTrack or via replaceTrack),
-          it continues to appear, but with the "detached" member set to True.
-        </p>
         <div>
           <pre class="idl">dictionary RTCMediaStreamTrackStats : RTCStats {
              DOMString           trackIdentifier;
@@ -1732,32 +1715,6 @@ enum RTCStatsType {
              boolean             ended;
              boolean             detached;
              DOMString           kind;
-             DOMHighResTimeStamp estimatedPlayoutTimestamp;
-             unsigned long       frameWidth;
-             unsigned long       frameHeight;
-             double              framesPerSecond;
-             unsigned long       framesCaptured;
-             unsigned long       framesSent;
-             unsigned long       keyFramesSent;
-             unsigned long       framesReceived;
-             unsigned long       keyFramesReceived;
-             unsigned long       framesDecoded;
-             unsigned long       framesDropped;
-             unsigned long       framesCorrupted;
-             unsigned long       partialFramesLost;
-             unsigned long       fullFramesLost;
-             double              audioLevel;
-             double              totalAudioEnergy;
-             boolean             voiceActivityFlag;
-             double              echoReturnLoss;
-             double              echoReturnLossEnhancement;
-             unsigned long long  totalSamplesSent;
-             unsigned long long  totalSamplesReceived;
-             double              totalSamplesDuration;
-             unsigned long long  concealedSamples;
-             unsigned long long  concealmentEvents;
-             double              jitterBufferDelay;
-             unsigned long long  jitterBufferEmittedCount;
              RTCPriorityType     priority;
 };</pre>
           <section>
@@ -1813,31 +1770,42 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn><code>estimatedPlayoutTimestamp</code></dfn> of type <span class=
-                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
+                <dfn><code>priority</code></dfn> of type <span class="idlMemberType"><a>
+                RTCPriorityType</a></span>
               </dt>
               <dd>
                 <p>
-                  Only valid for remote sources. This is the estimated playout time of this track.
-                  The playout time is the NTP timestamp of the last playable audio sample or video
-                  frame that has a known timestamp (from an RTCP SR packet mapping RTP timestamps
-                  to NTP timestamps), extrapolated with the time elapsed since it was ready to be
-                  played out. This is the "current time" of the track in NTP clock time of the
-                  sender and can be present even if there is no audio or video currently playing.
-                </p>
-                <p>
-                  This can be useful for estimating how much audio and video is out of sync for two
-                  tracks from the same source, <code>audioTrackStats.estimatedPlayoutTimestamp -
-                  videoTrackStats.estimatedPlayoutTimestamp</code>.
+                  Indicates the priority set for the track. It is specified in
+                  [[!RTCWEB-TRANSPORT]], Section 4.
                 </p>
               </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="vststats-dict*">
+        <h3>
+          <dfn>RTCVideoStreamTrackStats</dfn> dictionary
+        </h3>
+        <div>
+          <pre class="idl">dictionary RTCVideoStreamTrackStats : RTCMediaStreamTrackStats {
+             unsigned long       frameWidth;
+             unsigned long       frameHeight;
+             double              framesPerSecond;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCVideoStreamTrackStats</a> Members
+            </h2>
+            <dl data-link-for="RTCVideoStreamTrackStats" data-dfn-for="RTCVideoStreamTrackStats"
+            class="dictionary-members">
               <dt>
                 <dfn><code>frameWidth</code></dfn> of type <span class="idlMemberType"><a>unsigned
                 long</a></span>
               </dt>
               <dd>
                 <p>
-                  Only valid for video MediaStreamTracks and represents the width of the last
+                  Represents the width of the last
                   processed video frame for this track. Before the first frame is processed this
                   attribute is missing.
                 </p>
@@ -1848,7 +1816,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video MediaStreamTracks and represents the height of the last
+                  Represents the height of the last
                   processed video frame for this track. Before the first frame is processed this
                   attribute is missing.
                 </p>
@@ -1859,19 +1827,56 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It represents the nominal FPS value before the degradation
+                  Represents the nominal FPS value before the degradation
                   preference is applied. It is the number of complete frames in the last second.
                   For sending tracks it is the current captured FPS and for the receiving tracks it
                   is the current decoding framerate.
                 </p>
               </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="lvststats-dict*">
+        <h3>
+          <dfn>RTCLocalVideoStreamTrackStats</dfn> dictionary
+        </h3>
+        <p>
+          An RTCMLocalVideoStreamTrackStats object represents the stats about one attachment of a
+          video MediaStreamTrack to the PeerConnection object for which one calls getStats.
+        </p>
+        <p>
+          It appears in the stats as soon as it is attached (via addTrack, via addTransceiver, via
+          ReplaceTrack on an RTPSender object).
+        </p>
+        <p>
+          If a video track is attached twice (via addTransceiver or ReplaceTrack), there will
+          be two RTCLocalVideoStreamTrackStats objects, one for each attachment. They will have the same
+          "trackIdentifier" attribute, but different "id" attributes.
+        </p>
+        <p>
+          If the track is detached from the PeerConnection (via removeTrack or via replaceTrack),
+          it continues to appear, but with the "detached" member set to True.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCLocalVideoStreamTrackStats : RTCVideoStreamTrackStats {
+             unsigned long       framesCaptured;
+             unsigned long       framesSent;
+             unsigned long       keyFramesSent;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCLocalVideoStreamTrackStats</a> Members
+            </h2>
+            <dl data-link-for="RTCLocalVideoStreamTrackStats" data-dfn-for="RTCLocalVideoStreamTrackStats"
+            class="dictionary-members">
               <dt>
                 <dfn><code>framesCaptured</code></dfn> of type <span class=
                 "idlMemberType"><a>unsigned long</a></span>
               </dt>
               <dd>
                 <p>
-                  Only valid for local video. It represents the total number of frames captured for
+                  Represents the total number of frames captured for
                   this MediaStreamTrack, before encoding. For example, if this track represents a
                   camera this is the number of frames produced by the camera for this track, whose
                   framerate could vary due to hardware limitations or environmental factors such as
@@ -1884,8 +1889,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It represents the total number of frames sent for this
-                  MediaStreamTrack.
+                  Represents the total number of frames sent for this MediaStreamTrack.
                 </p>
               </dd>
               <dt>
@@ -1900,14 +1904,90 @@ enum RTCStatsType {
                   keyFramesSent</code> gives you the number of delta frames sent.
                 </p>
               </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="rvststats-dict*">
+        <h3>
+          <dfn>RTCRemoteVideoStreamTrackStats</dfn> dictionary
+        </h3>
+        <p>
+          An RTCRemoteVideoStreamTrackStats object represents the stats about one
+          video MediaStreamTrack coming from a PeerConnection object for which one calls getStats.
+        </p>
+        <p>
+          It appears in the stats as soon as it is created on an RTPReceiver object.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCRemoteVideoStreamTrackStats : RTCVideoStreamTrackStats {
+             DOMHighResTimeStamp estimatedPlayoutTimestamp;
+             double              jitterBufferDelay;
+             unsigned long long  jitterBufferEmittedCount;
+             unsigned long       framesReceived;
+             unsigned long       keyFramesReceived;
+             unsigned long       framesDecoded;
+             unsigned long       framesDropped;
+             unsigned long       framesCorrupted;
+             unsigned long       partialFramesLost;
+             unsigned long       fullFramesLost;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCRemoteVideoStreamTrackStats</a> Members
+            </h2>
+            <dl data-link-for="RTCRemoteVideoStreamTrackStats" data-dfn-for="RTCRemoteVideoStreamTrackStats"
+            class="dictionary-members">
+              <dt>
+                <dfn><code>estimatedPlayoutTimestamp</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
+              </dt>
+              <dd>
+                <p>
+                  This is the estimated playout time of this track.
+                  The playout time is the NTP timestamp of the last playable video
+                  frame that has a known timestamp (from an RTCP SR packet mapping RTP timestamps to
+                  NTP timestamps), extrapolated with the time elapsed since it was ready to be
+                  played out. This is the "current time" of the track in NTP clock time of the
+                  sender and can be present even if there is no video currently playing.
+                </p>
+                <p>
+                  This can be useful for estimating how much audio and video is out of sync for two
+                  tracks from the same source, <code>audioTrackStats.estimatedPlayoutTimestamp -
+                  videoTrackStats.estimatedPlayoutTimestamp</code>.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>jitterBufferDelay</code></dfn> of type <span class=
+                "idlMemberType"><a>double</a></span>
+              </dt>
+              <dd>
+                <p>
+                  It is the sum of the time, in seconds, each video frame takes from the time it
+                  is received and to the time it exits the jitter buffer. This increases upon
+                  frames exiting, having completed their time in the buffer (incrementing
+                  <code>jitterBufferEmittedCount</code>). The average jitter buffer delay can be
+                  calculated by dividing the <code>jitterBufferDelay</code> with the
+                  <code>jitterBufferEmittedCount</code>.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>jitterBufferEmittedCount</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The total number of video frames that have come out of the jitter
+                  buffer (increasing <code>jitterBufferDelay</code>).
+                </p>
+              </dd>
               <dt>
                 <dfn><code>framesReceived</code></dfn> of type <span class=
                 "idlMemberType"><a>unsigned long</a></span>
               </dt>
               <dd>
                 <p>
-                  Only valid for video and when remoteSource is set to <code>true</code>. It
-                  represents the total number of frames received for this MediaStreamTrack.
+                  Represents the total number of frames received for this MediaStreamTrack.
                 </p>
               </dd>
               <dt>
@@ -1929,8 +2009,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video and when remoteSource is set to <code>true</code>. It
-                  represents the total number of frames correctly decoded for this
+                  Represents the total number of frames correctly decoded for this
                   MediaStreamTrack, independent of which SSRC it was received from. It is defined
                   as <code>totalVideoFrames</code> in Section 5 of [[!MEDIA-SOURCE]].
                 </p>
@@ -1941,7 +2020,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It is the total number of frames dropped predecode or
+                  The total number of frames dropped predecode or
                   dropped because the frame missed its display deadline for this MediastreamTrack.
                   It is the same definition as <code>droppedVideoFrames</code> in Section 5 of
                   [[!MEDIA-SOURCE]].
@@ -1953,7 +2032,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It is the total number of corrupted frames that have been
+                  The total number of corrupted frames that have been
                   detected for this MediaStreamTrack. It is the same definition as
                   <code>corruptedVideoFrames</code> in Section 5 of [[!MEDIA-SOURCE]].
                 </p>
@@ -1964,7 +2043,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. <code>partialFramesLost</code> is the cumulative number of
+                  The cumulative number of
                   partial frames lost, as defined in Appendix A (j) of [[!RFC7004]].
                 </p>
               </dd>
@@ -1974,17 +2053,38 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. <code>fullFramesLost</code> is the cumulative number of
+                  The cumulative number of
                   full frames lost, as defined in Appendix A (i) of [[!RFC7004]].
                 </p>
               </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="aststats-dict*">
+        <h3>
+          <dfn>RTCAudioStreamTrackStats</dfn> dictionary
+        </h3>
+        <div>
+          <pre class="idl">dictionary RTCAudioStreamTrackStats : RTCMediaStreamTrackStats {
+             double              audioLevel;
+             double              totalAudioEnergy;
+             boolean             voiceActivityFlag;
+             double              totalSamplesDuration;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCAudioStreamTrackStats</a> Members
+            </h2>
+            <dl data-link-for="RTCAudioStreamTrackStats" data-dfn-for="RTCAudioStreamTrackStats"
+            class="dictionary-members">
               <dt>
                 <dfn><code>audioLevel</code></dfn> of type <span class=
                 "idlMemberType"><a>double</a></span>
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. The value is between 0..1 (linear), where 1.0 represents 0
+                  The value is between 0..1 (linear), where 1.0 represents 0
                   dBov, 0 represents silence, and 0.5 represents approximately 6 dBSPL change in
                   the sound pressure level from 0 dBov.
                 </p>
@@ -2003,7 +2103,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. This value MUST be computed as follows: for each audio
+                  This value MUST be computed as follows: for each audio
                   sample sent/received for this object (and counted by
                   <code><a>totalSamplesSent</a></code> or
                   <code><a>totalSamplesReceived</a></code>), add the sample's value divided by the
@@ -2038,7 +2138,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. Whether the last RTP packet sent or played out by this
+                  Whether the last RTP packet sent or played out by this
                   track contained voice activity or not based on the presence of the V bit in the
                   extension header, as defined in [[RFC6464]].
                 </p>
@@ -2049,12 +2149,63 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
+                <dfn><code>totalSamplesDuration</code></dfn> of type <span class="idlMemberType"><a>
+                double</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the total duration
+                  in seconds of all samples that have sent or received (and
+                  thus counted by <code><a>totalSamplesSent</a></code> or
+                  <code><a>totalSamplesReceived</a></code>). Can be used with
+                  <code><a>totalAudioEnergy</a></code> to compute an average audio
+                  level over different intervals.
+                </p>
+              </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="laststats-dict*">
+        <h3>
+          <dfn>RTCLocalAudioStreamTrackStats</dfn> dictionary
+        </h3>
+        <p>
+          An RTCMLocalVideoStreamTrackStats object represents the stats about one attachment of an
+          audio MediaStreamTrack to the PeerConnection object for which one calls getStats.
+        </p>
+        <p>
+          It appears in the stats as soon as it is attached (via addTrack, via addTransceiver, via
+          ReplaceTrack on an RTPSender object).
+        </p>
+        <p>
+          If an audio track is attached twice (via addTransceiver or ReplaceTrack), there will
+          be two RTCLocalAudioStreamTrackStats objects, one for each attachment. They will have the same
+          "trackIdentifier" attribute, but different "id" attributes.
+        </p>
+        <p>
+          If the track is detached from the PeerConnection (via removeTrack or via replaceTrack),
+          it continues to appear, but with the "detached" member set to True.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCLocalAudioStreamTrackStats : RTCAudioStreamTrackStats {
+             double              echoReturnLoss;
+             double              echoReturnLossEnhancement;
+             unsigned long long  totalSamplesSent;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCLocalAudioStreamTrackStats</a> Members
+            </h2>
+            <dl data-link-for="RTCLocalAudioStreamTrackStats" data-dfn-for="RTCLocalAudioStreamTrackStats"
+            class="dictionary-members">
+              <dt>
                 <dfn><code>echoReturnLoss</code></dfn> of type <span class=
                 "idlMemberType"><a>double</a></span>
               </dt>
               <dd>
                 <p>
-                  Only present on audio tracks sourced from a microphone where echo cancellation is
+                  Only present on tracks sourced from a microphone where echo cancellation is
                   applied. Calculated in decibels, as defined in [[!ECHO]] (2012) section 3.14.
                 </p>
               </dd>
@@ -2064,7 +2215,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only present on audio tracks sourced from a microphone where echo cancellation is
+                  Only present on tracks sourced from a microphone where echo cancellation is
                   applied. Calculated in decibels, as defined in [[!ECHO]] (2012) section 3.15.
                 </p>
               </dd>
@@ -2074,56 +2225,56 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only present for outbound audio tracks. The total number of audio samples that
-                  have been sent for this track.
+                  The total number of audio samples that have been sent for this track.
                 </p>
               </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+      <section id="raststats-dict*">
+        <h3>
+          <dfn>RTCRemoteAudioStreamTrackStats</dfn> dictionary
+        </h3>
+        <p>
+          An RTCRemoteAudioStreamTrackStats object represents the stats about one
+          audio MediaStreamTrack coming from a PeerConnection object for which one calls getStats.
+        </p>
+        <p>
+          It appears in the stats as soon as it is created on an RTPReceiver object.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCRemoteAudioStreamTrackStats : RTCAudioStreamTrackStats {
+             DOMHighResTimeStamp estimatedPlayoutTimestamp;
+             double              jitterBufferDelay;
+             unsigned long long  jitterBufferEmittedCount;
+             unsigned long long  totalSamplesReceived;
+             unsigned long long  concealedSamples;
+             unsigned long long  concealmentEvents;
+};</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCRemoteAudioStreamTrackStats</a> Members
+            </h2>
+            <dl data-link-for="RTCRemoteAudioStreamTrackStats" data-dfn-for="RTCRemoteAudioStreamTrackStats"
+            class="dictionary-members">
               <dt>
-                <dfn><code>totalSamplesReceived</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long long</a></span>
+                <dfn><code>estimatedPlayoutTimestamp</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMHighResTimeStamp</a></span>
               </dt>
               <dd>
                 <p>
-                  Only present for inbound audio tracks. The total number of audio samples that
-                  have been received for this track. This includes <a>concealedSamples</a>.
+                  This is the estimated playout time of this track.
+                  The playout time is the NTP timestamp of the last playable audio sample
+                  that has a known timestamp (from an RTCP SR packet mapping RTP timestamps to
+                  NTP timestamps), extrapolated with the time elapsed since it was ready to be
+                  played out. This is the "current time" of the track in NTP clock time of the
+                  sender and can be present even if there is no audio currently playing.
                 </p>
-              </dd>
-              <dt>
-                <dfn><code>totalSamplesDuration</code></dfn> of type <span class=
-                "idlMemberType"><a>double</a></span>
-              </dt>
-              <dd>
                 <p>
-                  Only present for audio tracks. Represents the total duration in seconds of all
-                  samples that have sent or received (and thus counted by
-                  <code><a>totalSamplesSent</a></code> or
-                  <code><a>totalSamplesReceived</a></code>). Can be used with
-                  <code><a>totalAudioEnergy</a></code> to compute an average audio level over
-                  different intervals.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>concealedSamples</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Only present for inbound audio tracks. The total number of inbound audio samples
-                  that are concealed samples. A concealed sample is a sample that is based on data
-                  that was synthesized to conceal packet loss and does not represent incoming data.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>concealmentEvents</code></dfn> of type <span class=
-                "idlMemberType"><a>unsigned long long</a></span>
-              </dt>
-              <dd>
-                <p>
-                  Only present for inbound audio tracks. The number of concealment events. This
-                  counter increases every time a concealed sample is synthesized after a
-                  non-concealed sample. That is, multiple consecutive concealed samples will
-                  increase the <a>concealedSamples</a> count multiple times but is a single
-                  concealment event.
+                  This can be useful for estimating how much audio and video is out of sync for two
+                  tracks from the same source, <code>audioTrackStats.estimatedPlayoutTimestamp -
+                  videoTrackStats.estimatedPlayoutTimestamp</code>.
                 </p>
               </dd>
               <dt>
@@ -2132,9 +2283,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  It is the sum of the time, in seconds, each audio sample or video frame takes from
-                  the time it is received and to the time it exits the jitter buffer. This increases
-                  upon samples/frames exiting, having completed their time in the buffer (incrementing
+                  It is the sum of the time, in seconds, each audio sample takes from the time it
+                  is received and to the time it exits the jitter buffer. This increases upon
+                  samples exiting, having completed their time in the buffer (incrementing
                   <code>jitterBufferEmittedCount</code>). The average jitter buffer delay can be
                   calculated by dividing the <code>jitterBufferDelay</code> with the
                   <code>jitterBufferEmittedCount</code>.
@@ -2146,18 +2297,42 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The total number of audio samples or video frames that have come out of the jitter
+                  The total number of audio samples that have come out of the jitter
                   buffer (increasing <code>jitterBufferDelay</code>).
                 </p>
               </dd>
               <dt>
-                <dfn><code>priority</code></dfn> of type <span class=
-                "idlMemberType"><a>RTCPriorityType</a></span>
+                <dfn><code>totalSamplesReceived</code></dfn> of type <span class="idlMemberType"><a>
+                unsigned long long</a></span>
               </dt>
               <dd>
                 <p>
-                  Indicates the priority set for the track. It is specified in
-                  [[!RTCWEB-TRANSPORT]], Section 4.
+                  The total number of audio samples that have
+                  been received for this track. This includes <a>concealedSamples</a>.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>concealedSamples</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The total number of samples
+                  that are concealed samples. A concealed sample is a sample that is based on data
+                  that was synthesized to conceal packet loss and does not represent incoming data.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>concealmentEvents</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The number of concealment events. This
+                  counter increases every time a concealed sample is synthesized after a
+                  non-concealed sample. That is, multiple consecutive concealed samples will
+                  increase the <a>concealedSamples</a> count multiple times but is a single
+                  concealment event.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1910,7 +1910,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It represents the total number of key
+                  Represents the total number of key
                   frames sent by this RTCRtpSender (or for this MediaStreamTrack,
                   if <code>type</code> is <code>"track"</code>), such as
                   Infra-frames in VP8 [[RFC6386]] or I-frames in H.264
@@ -2056,8 +2056,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video and when remoteSource is set to <code>true</code>. It
-                  represents the total number of key frames received for this MediaStreamTrack,
+                  Represents the total number of key frames received for this MediaStreamTrack,
                   such as Infra-frames in VP8 [[RFC6386]] or I-frames in H.264 [[RFC6184]]. This is
                   a subset of <code>framesReceived</code>. <code>framesReceived -
                   keyFramesReceived</code> gives you the number of delta frames received.


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-stats/issues/231 (includes/on-top-of patch from https://github.com/w3c/webrtc-stats/pull/272).