### PR TITLE
Adding dtlsCipher and srtpCipher

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2141,6 +2141,8 @@ enum RTCStatsType {
              DOMString             selectedCandidatePairId;
              DOMString             localCertificateId;
              DOMString             remoteCertificateId;
+             DOMString             dtlsCipher;
+             DOMString             srtpCipher;
 };</pre>
           <section>
             <h2>
@@ -2243,6 +2245,32 @@ enum RTCStatsType {
               <dd>
                 <p>
                   For components where DTLS is negotiated, give remote certificate.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>dtlsCipher</code></dfn> of
+                type <span class="idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Descriptive name of the cipher suite used for the DTLS
+                  transport, as defined in the "Description" column of
+                  the IANA cipher
+                  suite registry (https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4)
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>srtpCipher</code></dfn> of
+                type <span class="idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Descriptive name of the protection profile used for
+                  the SRTP transport, as defined in the "Profile"
+                  column of the IANA DTLS-SRTP protection profile
+                  registry
+                  (https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml)
+                  and described further in [[RFC5764]].
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2256,7 +2256,7 @@ enum RTCStatsType {
                   Descriptive name of the cipher suite used for the DTLS
                   transport, as defined in the "Description" column of
                   the IANA cipher
-                  suite registry (https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4)
+                  suite registry [[!IANA-TLS-CIPHERS]].
                 </p>
               </dd>
               <dt>
@@ -2268,8 +2268,7 @@ enum RTCStatsType {
                   Descriptive name of the protection profile used for
                   the SRTP transport, as defined in the "Profile"
                   column of the IANA DTLS-SRTP protection profile
-                  registry
-                  (https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml)
+                  registry [[!IANA-DTLS-SRTP]]
                   and described further in [[RFC5764]].
                 </p>
               </dd>


### PR DESCRIPTION
Fixes #248

Note: https://github.com/tobie/specref/pull/428 adds
[[IANA-DTLS-SRTP]] and [[IANA-TLS-CIPHERS]] to specref; PR should be
updated with these if it lands before this one is ready.