### PR TITLE
Use underlines instead of record<a,b> for qualityLimitationDurations

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1237,7 +1237,7 @@ enum RTCStatsType {
              double               totalEncodeTime;
              double               averageRTCPInterval;
              RTCQualityLimitationReason                 qualityLimitationReason;
-             record(RTCQualityLimitationReason, double) qualityLimitationDurations;
+             record_RTCQualityLimitationReason__double_ qualityLimitationDurations;
 };</pre>
           <section>
             <h2>
@@ -1328,7 +1328,7 @@ enum RTCStatsType {
               </dd>
               <dt>
                 <dfn><code>qualityLimitationDurations</code></dfn> of type <span class=
-                "idlMemberType"><a>record(RTCQualityLimitationReason, double)</a></span>
+                "idlMemberType"><a>record_RTCQualityLimitationReason__double_</a></span>
               </dt>
               <dd>
                 <p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1237,7 +1237,7 @@ enum RTCStatsType {
              double               totalEncodeTime;
              double               averageRTCPInterval;
              RTCQualityLimitationReason                 qualityLimitationReason;
-             record&lt;RTCQualityLimitationReason, double&gt; qualityLimitationDurations;
+             record(RTCQualityLimitationReason, double) qualityLimitationDurations;
 };</pre>
           <section>
             <h2>
@@ -1328,7 +1328,7 @@ enum RTCStatsType {
               </dd>
               <dt>
                 <dfn><code>qualityLimitationDurations</code></dfn> of type <span class=
-                "idlMemberType"><a>record&lt;RTCQualityLimitationReason, double&gt;</a></span>
+                "idlMemberType"><a>record(RTCQualityLimitationReason, double)</a></span>
               </dt>
               <dd>
                 <p>


### PR DESCRIPTION
#270 broke travis build. Despite using `&lt;` and `&gt;` it got confused. Attempted temporary fix to replace them with parenthesis but that also failed the travis build. Using underscores.

Broken build: https://travis-ci.org/w3c/webrtc-stats/builds/313432008

Temporary fix:
record_RTCQualityLimitationReason__double_
Should be:
record<RTCQualityLimitationReason, double>

I'll file a bug. Maybe ReSpec needs to be fixed.