### PR TITLE
fix for timestamp for remote and local objects

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -799,7 +799,7 @@ enum RTCStatsType {
                 <p>
                   The definition of QP value depends on the <a>codec</a>; for VP8, the QP value is
                   the value carried in the frame header as the syntax element "y_ac_qi", and
-                  defined in [[RFC6386]] section 19.2. Its range is 0..127. 
+                  defined in [[RFC6386]] section 19.2. Its range is 0..127.
                   <!-- Need appropriate references for VP9 and H.264 -->
                 </p>
                 <p>
@@ -1159,7 +1159,8 @@ enum RTCStatsType {
         </h3>
         <p>
           The <dfn>RTCInboundRTPStreamStats</dfn> dictionary represents the measurement metrics for
-          the incoming RTP media stream.
+          the incoming RTP media stream. The timestamp reported in the statistics object is the time
+          at which the data was sampled.
         </p>
         <div>
           <pre class="idl">dictionary RTCInboundRTPStreamStats : RTCReceivedRTPStreamStats {
@@ -1251,7 +1252,9 @@ enum RTCStatsType {
         </h3>
         <p>
           The <dfn>RTCRemoteInboundRTPStreamStats</dfn> dictionary represents the remote endpoint's
-          measurement metrics for its incoming RTP stream (our outgoing RTP stream).
+          measurement metrics for a particular incoming RTP stream (corresponding to an outgoing
+          RTP stream at the sending endpoint). The timestamp reported in the statistics object is
+          the time at which the corresponding RTCP RR was received.
         </p>
         <div>
           <pre class="idl">dictionary RTCRemoteInboundRTPStreamStats : RTCReceivedRTPStreamStats {
@@ -1372,7 +1375,8 @@ enum RTCStatsType {
         </h3>
         <p>
           The <dfn>RTCOutboundRTPStreamStats</dfn> dictionary represents the measurement metrics
-          for the outgoing RTP stream.
+          for the outgoing RTP stream. The timestamp reported in the statistics object is the time
+          at which the data was sampled.
         </p>
         <div>
           <pre class="idl">dictionary RTCOutboundRTPStreamStats : RTCSentRTPStreamStats {
@@ -1575,7 +1579,9 @@ enum RTCStatsType {
         </h3>
         <p>
           The <dfn>RTCRemoteOutboundRTPStreamStats</dfn> dictionary represents the remote
-          endpoint's measurement metrics for its outgoing RTP stream (our incoming RTP stream).
+          endpoint's measurement metrics for its outgoing RTP stream (corresponding to an
+          outgoing RTP stream at the sending endpoint). The timestamp reported in the
+          statistics object is the time at which the corresponding RTCP SR was received.
         </p>
         <div>
           <pre class="idl">dictionary RTCRemoteOutboundRTPStreamStats : RTCSentRTPStreamStats {


### PR DESCRIPTION
An attempt fix the issue with timestamp live (local) and reported (remote) stats. Fixes #313 