### PR TITLE
Update webrtc-respec-ci integration following respec current practices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,37 @@
 language: python
 
+dist: trusty
+
 branches:
   only:
     - /.*/
 
 python:
   - "2.7_with_system_site_packages"
+
 sudo: false
+
 addons:
   apt:
-    sources:
-      - george-edison55-precise-backports
-      - ubuntu-toolchain-r-test
     packages:
       - libwww-perl
       - libcss-dom-perl
       - python-lxml
       - cmake
-      - cmake-data
       - gcc-4.8
       - g++-4.8
+  chrome: stable
+
+cache:
+  directories:
+    - node_modules # NPM packages
+
 before_install:
-  - export CXX="g++-4.8" CC="gcc-4.8"
-  - nvm install 8
-  - "export DISPLAY=:99.0"
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
-  - sh -e /etc/init.d/xvfb start
+  - nvm install lts/*
+
 install:
  - make travissetup
+
 script:
  - make check
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ branches:
   only:
     - /.*/
 
-python:
-  - "2.7_with_system_site_packages"
-
 sudo: false
 
 addons:
@@ -16,10 +13,6 @@ addons:
     packages:
       - libwww-perl
       - libcss-dom-perl
-      - python-lxml
-      - cmake
-      - gcc-4.8
-      - g++-4.8
   chrome: stable
 
 cache:


### PR DESCRIPTION
- Use Node LTS version
- Cache NPM packages
- Now using Chrome headless instead of Xvfb for browser testing
- GCC, cmake, python 2.x and 3.x are installed by default on Travis