### PR TITLE
Re-added remoteSource to RTCMediaHandlerStats

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1924,6 +1924,7 @@ enum RTCStatsType {
         <div>
           <pre class="idl">dictionary RTCMediaHandlerStats : RTCStats {
              DOMString           trackIdentifier;
+             boolean             remoteSource;
              boolean             ended;
              DOMString           kind;
              RTCPriorityType     priority;
@@ -1948,8 +1949,8 @@ enum RTCStatsType {
                 "idlMemberType"><a>boolean</a></span>
               </dt>
               <dd>
-                True if the source is remote, for instance if it is sourced from another host via
-                an RTCPeerConnection. False otherwise.
+                Only applicable for 'track' stats. True if the source is remote, for instance if it
+                is sourced from another host via an RTCPeerConnection. False otherwise.
               </dd>
               <dt>
                 <dfn><code>ended</code></dfn> of type <span class=


### PR DESCRIPTION
Fixes #341.

Updated the description: Only applicable for 'track' stats.