### PR TITLE
relayprotocol: simplifiy language

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2988,8 +2988,8 @@ enum RTCStatsType {
               <dd>
                 <p>
                   It is the protocol used by the endpoint to communicate with the TURN server. This
-                  is only present for local candidates. Valid values for the TURN URL protocol is
-                  one of <code>udp</code>, <code>tcp</code>, or <code>tls</code>.
+                  is only present for local candidates. Valid values are
+                  <code>udp</code>, <code>tcp</code>, or <code>tls</code>.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
simplifies the language of the relayProtocol definition and avoids
confusion with TURN urls