### PR TITLE
Rename RTCIceCandidateStats.ip to address.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2958,7 +2958,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  It is the IP address of the candidate, allowing for IPv4 addresses, IPv6
+                  It is the address of the candidate, allowing for IPv4 addresses, IPv6
                   addresses, and fully qualified domain names (FQDNs). See
                   [[!RFC5245]] section 15.1 for details.
                 </p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2909,7 +2909,7 @@ enum RTCStatsType {
           <pre class="idl">dictionary RTCIceCandidateStats : RTCStats {
              DOMString                transportId;
              RTCNetworkType           networkType;
-             DOMString                ip;
+             DOMString                address;
              long                     port;
              DOMString                protocol;
              RTCIceCandidateType      candidateType;
@@ -2953,13 +2953,13 @@ enum RTCStatsType {
                 </div>
               </dd>
               <dt>
-                <dfn><code>ip</code></dfn> of type <span class=
+                <dfn><code>address</code></dfn> of type <span class=
                 "idlMemberType"><a>DOMString</a></span>
               </dt>
               <dd>
                 <p>
-                  It is the IP address of the candidate, allowing for IPv4 addresses and IPv6
-                  addresses, but fully qualified domain names (FQDNs) are not allowed. See
+                  It is the IP address of the candidate, allowing for IPv4 addresses, IPv6
+                  addresses, and fully qualified domain names (FQDNs). See
                   [[!RFC5245]] section 15.1 for details.
                 </p>
               </dd>


### PR DESCRIPTION
Fix for https://github.com/w3c/webrtc-pc/issues/1913.