### PR TITLE
add stunserverconnectionstats

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3639,7 +3639,6 @@ enum RTCNetworkType {
         <div>
           <pre class="idl">dictionary RTCStunServerConnectionStats : RTCStats {
              DOMString url;
-             DOMString address;
              long port;
              DOMString protocol;
              RTCNetworkType networkType;
@@ -3660,17 +3659,6 @@ enum RTCNetworkType {
               <dd>
                 <p>
                   The URL of the TURN or STUN server.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>address</code></dfn> of type <span class=
-                "idlMemberType"><a>DOMString</a></span>
-              </dt>
-              <dd>
-                <p>
-                  It is the IP address of the local interface, allowing for IPv4 addresses
-                  and IPv6 addresses, and fully qualified domain names (FQDNs).
-                  See [RFC5245] section 15.1 for details.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3632,109 +3632,107 @@ enum RTCNetworkType {
           </section>
         </div>
       </section>
-
-    <section id="stunserverconnection-dict*">
-      <h3>
-        <dfn>RTCStunServerConnectionStats</dfn> dictionary
-      </h3>
-      <div>
-        <pre class="idl">dictionary RTCStunServerConnectionStats : RTCStats {
-           DOMString url;
-           DOMString address;
-           long port;
-           DOMString protocol;
-           RTCNetworkType networkType;
-           unsigned long totalRequestsSent;
-           unsigned long totalResponsesReceived;
-           double totalRoundTripTime;
-};</pre>
-        <section>
-          <h2>
-            Dictionary <a class="idlType">RTCStunServerConnectionStats</a> Members
-          </h2>
-          <dl data-link-for="RTCStunServerConnectionStats" data-dfn-for=
-          "RTCStunServerConnectionStats" class="dictionary-members">
-            <dt>
-              <dfn><code>url</code></dfn> of type <span class=
-              "idlMemberType"><a>DOMString</a></span>
-            </dt>
-            <dd>
-              <p>
-                The URL of the TURN or STUN server.
-              </p>
-            </dd>
-            <dt>
-              <dfn><code>address</code></dfn> of type <span class=
-              "idlMemberType"><a>DOMString</a></span>
-            </dt>
-            <dd>
-              <p>
-                It is the IP address of the local interface, allowing for IPv4 addresses
-                and IPv6 addresses, and fully qualified domain names (FQDNs).
-                See [RFC5245] section 15.1 for details.
-              </p>
-            </dd>
-            <dt>
-              <dfn><code>port</code></dfn> of type <span class=
-              "idlMemberType"><a>long</a></span>
-            </dt>
-            <dd>
-              <p>
-                It is the port number used by the client.
-              </p>
-            </dd>
-            <dt>
-              <dfn><code>protocol</code></dfn> of type <span class=
-              "idlMemberType"><a>DOMString</a></span>
-            </dt>
-            <dd>
-              <p>
-                Valid values for transport is one of <code>udp</code> and <code>tcp</code>.
-                Based on the "transport" defined in [RFC5245] section 15.1.
-              </p>
-            </dd>
-            <dt>
-              <dfn><code>networkType</code></dfn> of type <span class=
-              "idlMemberType"><a>RTCNetworkType</a></span>
-            </dt>
-            <dd>
-              <p>
-                Represents the type of network interface used.
-              </p>
-            </dd>
-            <dt>
-              <dfn><code>totalRequestsSent</code></dfn> of type <span class=
-              "idlMemberType"><a>unsigned long</a></span>
-            </dt>
-            <dd>
-              <p>
-                The total amount of requests that have been sent to this server.
-              </p>
-            </dd>
-            <dt>
-              <dfn><code>totalResponsesReceived</code></dfn> of type <span class=
-              "idlMemberType"><a>unsigned long</a></span>
-            </dt>
-            <dd>
-              <p>
-                The total amount of responses received from this server.
-              </p>
-            </dd>
-            <dt>
-              <dfn><code>totalRoundTripTime</code></dfn> of type <span class=
-              "idlMemberType"><a>double</a></span>
-            </dt>
-            <dd>
-              <p>
-                The sum of RTTs for all requests that have been sent where a
-                response has been received.
-              </p>
-            </dd>
-          </dl>
-        </section>
-      </div>
-    </section>
-
+      <section id="stunserverconnection-dict*">
+        <h3>
+          <dfn>RTCStunServerConnectionStats</dfn> dictionary
+        </h3>
+        <div>
+          <pre class="idl">dictionary RTCStunServerConnectionStats : RTCStats {
+             DOMString url;
+             DOMString address;
+             long port;
+             DOMString protocol;
+             RTCNetworkType networkType;
+             unsigned long totalRequestsSent;
+             unsigned long totalResponsesReceived;
+             double totalRoundTripTime;
+  };</pre>
+          <section>
+            <h2>
+              Dictionary <a class="idlType">RTCStunServerConnectionStats</a> Members
+            </h2>
+            <dl data-link-for="RTCStunServerConnectionStats" data-dfn-for=
+            "RTCStunServerConnectionStats" class="dictionary-members">
+              <dt>
+                <dfn><code>url</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The URL of the TURN or STUN server.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>address</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  It is the IP address of the local interface, allowing for IPv4 addresses
+                  and IPv6 addresses, and fully qualified domain names (FQDNs).
+                  See [RFC5245] section 15.1 for details.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>port</code></dfn> of type <span class=
+                "idlMemberType"><a>long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  It is the port number used by the client.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>protocol</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Valid values for transport is one of <code>udp</code> and <code>tcp</code>.
+                  Based on the "transport" defined in [RFC5245] section 15.1.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>networkType</code></dfn> of type <span class=
+                "idlMemberType"><a>RTCNetworkType</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the type of network interface used.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>totalRequestsSent</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The total amount of requests that have been sent to this server.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>totalResponsesReceived</code></dfn> of type <span class=
+                "idlMemberType"><a>unsigned long</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The total amount of responses received from this server.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>totalRoundTripTime</code></dfn> of type <span class=
+                "idlMemberType"><a>double</a></span>
+              </dt>
+              <dd>
+                <p>
+                  The sum of RTTs for all requests that have been sent where a
+                  response has been received.
+                </p>
+              </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
     </section>
     <section>
       <h2>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -442,7 +442,8 @@ enum RTCStatsType {
 "candidate-pair",
 "local-candidate",
 "remote-candidate",
-"certificate"
+"certificate",
+"stunserverconnection"
 };
         </pre>
         <p>
@@ -635,6 +636,15 @@ enum RTCStatsType {
             <p>
               Information about a certificate used by an RTCIceTransport. It is accessed by the
               <code><a>RTCCertificateStats</a></code>.
+            </p>
+          </dd>
+          <dt>
+            <dfn><code>stunserverconnection</code></dfn>
+          </dt>
+          <dd>
+            <p>
+              Information about the connection to a STUN or TURN server. It is accessed by the
+              <code><a>RTCStunServerConnectionStats</a></code>.
             </p>
           </dd>
         </dl>
@@ -3622,6 +3632,109 @@ enum RTCNetworkType {
           </section>
         </div>
       </section>
+
+    <section id="stunserverconnection-dict*">
+      <h3>
+        <dfn>RTCStunServerConnectionStats</dfn> dictionary
+      </h3>
+      <div>
+        <pre class="idl">dictionary RTCStunServerConnectionStats : RTCStats {
+           DOMString url;
+           DOMString address;
+           long port;
+           DOMString protocol;
+           RTCNetworkType networkType;
+           unsigned long totalRequestsSent;
+           unsigned long totalResponsesReceived;
+           double totalRoundTripTime;
+};</pre>
+        <section>
+          <h2>
+            Dictionary <a class="idlType">RTCStunServerConnectionStats</a> Members
+          </h2>
+          <dl data-link-for="RTCStunServerConnectionStats" data-dfn-for=
+          "RTCStunServerConnectionStats" class="dictionary-members">
+            <dt>
+              <dfn><code>url</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>
+            </dt>
+            <dd>
+              <p>
+                The URL of the TURN or STUN server.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>address</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>
+            </dt>
+            <dd>
+              <p>
+                It is the IP address of the local interface, allowing for IPv4 addresses
+                and IPv6 addresses, and fully qualified domain names (FQDNs).
+                See [RFC5245] section 15.1 for details.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>port</code></dfn> of type <span class=
+              "idlMemberType"><a>long</a></span>
+            </dt>
+            <dd>
+              <p>
+                It is the port number used by the client.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>protocol</code></dfn> of type <span class=
+              "idlMemberType"><a>DOMString</a></span>
+            </dt>
+            <dd>
+              <p>
+                Valid values for transport is one of <code>udp</code> and <code>tcp</code>.
+                Based on the "transport" defined in [RFC5245] section 15.1.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>networkType</code></dfn> of type <span class=
+              "idlMemberType"><a>RTCNetworkType</a></span>
+            </dt>
+            <dd>
+              <p>
+                Represents the type of network interface used.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>totalRequestsSent</code></dfn> of type <span class=
+              "idlMemberType"><a>unsigned long</a></span>
+            </dt>
+            <dd>
+              <p>
+                The total amount of requests that have been sent to this server.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>totalResponsesReceived</code></dfn> of type <span class=
+              "idlMemberType"><a>unsigned long</a></span>
+            </dt>
+            <dd>
+              <p>
+                The total amount of responses received from this server.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>totalRoundTripTime</code></dfn> of type <span class=
+              "idlMemberType"><a>double</a></span>
+            </dt>
+            <dd>
+              <p>
+                The sum of RTTs for all requests that have been sent where a
+                response has been received.
+              </p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+    </section>
+
     </section>
     <section>
       <h2>


### PR DESCRIPTION
Adds RTCStunServerConnectionStats as discussed as discussed in issue #339 .
I have added networkType, as I think it might be useful if the server is not responding (can be an access network issue).

Some questions:
1. do we want to have networkType here? if yes, should it remain as a subsection of ICE candidate stats?
2. with url, local address and port, I think we can uniquely link these stats to relevant candidates if wanted, or am I missing something? :)
3. is having url only to describe the server enough? with DNS load balancers it would be possible to have several servers behind a url
