### PR TITLE
Fix capitalization mismatch in RTCRTPStreamStats

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3734,7 +3734,7 @@ enum RTCNetworkType {
             </dd>
           </dl>
         </section>
-        <pre class="idl">partial dictionary RTCRTPStreamStats {
+        <pre class="idl">partial dictionary RTCRtpStreamStats {
              DOMString           mediaType;
              double              averageRTCPInterval;
 };</pre>


### PR DESCRIPTION
Introduced in https://github.com/w3c/webrtc-stats/pull/327, right after
https://github.com/w3c/webrtc-stats/pull/333 renamed the dictionary.