### PR TITLE
Fix partial dictionary RTCInboundRtpStreamStats typo

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3928,19 +3928,19 @@ enum RTCNetworkType {
             </dd>
           </dl>
         </section>
-        <pre class="idl">partial dictionary RTCInboundStreamStats {
+        <pre class="idl">partial dictionary RTCInboundRtpStreamStats {
           double fractionLost;
 };</pre>
         <section>
-          <h2>Obsolete RTCInboundStreamStats members</h2>
-          <dl data-dfn-for="RTCInboundStreamStats">
+          <h2>Obsolete RTCInboundRtpStreamStats members</h2>
+          <dl data-dfn-for="RTCInboundRtpStreamStats">
             <dt>
               <dfn><code>fractionLost</code></dfn> of
               type <span class="idlMemberType"><a>double</a></span>
             </dt>
             <dd>
               <p>
-                This field was moved to RTCRemoteInboundStreamStats in
+                This field was moved to RTCRemoteInboundRtpStreamStats in
                 December 2017.
               </p>
             </dd>


### PR DESCRIPTION
Introduced in https://github.com/w3c/webrtc-stats/pull/389.

Original dictionary definition:
https://w3c.github.io/webrtc-stats/#inboundrtpstats-dict*