### PR TITLE
Replace RTCVideo{Sender,Receiver}Stats::keyFrames{Sent,Received} with RTC{Out,In}boundRtpStreamStats::keyFrames{En,De}coded

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1146,6 +1146,7 @@ enum RTCStatsType {
              DOMString            receiverId;
              DOMString            remoteId;
              unsigned long        framesDecoded;
+             unsigned long        keyFramesDecoded;
              unsigned long long   qpSum;
              DOMHighResTimeStamp  lastPacketReceivedTimestamp;
              double               averageRtcpInterval;
@@ -1202,6 +1203,18 @@ enum RTCStatsType {
                 <p>
                   Only valid for video. It represents the total number of frames correctly decoded
                   for this SSRC, i.e., frames that would be displayed if no frames are dropped.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>keyFramesDecoded</code></dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  Only valid for video. It represents the total number of key frames, such as
+                  key frames in VP8 [[RFC6386]] or IDR-frames in H.264 [[RFC6184]], successfully decoded for this RTP media stream.
+                  This is a subset of <code>framesDecoded</code>. <code>framesDecoded - keyFramesDecoded</code> gives
+                  you the number of delta frames decoded.
                 </p>
               </dd>
               <dt>
@@ -1649,7 +1662,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Only valid for video. It represents the total number of key frames, such as
-                  keyframes in VP8 [[RFC6386]] or IDR-frames in H.264 [[RFC6184]], successfully encoded for this RTP media stream.
+                  key frames in VP8 [[RFC6386]] or IDR-frames in H.264 [[RFC6184]], successfully encoded for this RTP media stream.
                   This is a subset of <code>framesEncoded</code>. <code>framesEncoded - keyFramesEncoded</code> gives
                   you the number of delta frames encoded.
                 </p>
@@ -2524,7 +2537,6 @@ enum RTCStatsType {
              double              jitterBufferDelay;
              unsigned long long  jitterBufferEmittedCount;
              unsigned long       framesReceived;
-             unsigned long       keyFramesReceived;
              unsigned long       framesDecoded;
              unsigned long       framesDropped;
              unsigned long       partialFramesLost;
@@ -2588,21 +2600,6 @@ enum RTCStatsType {
                 <p>
                   Represents the total number of complete frames received for this receiver. This
                   metric is incremented when the complete frame is received.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>keyFramesReceived</code></dfn> of type <span class=
-                "idlMemberType">unsigned long</span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of complete key frames received for this
-                  MediaStreamTrack, such as Infra-frames in VP8 [[RFC6386]] or I-frames in H.264
-                  [[RFC6184]]. This is a subset of <code>framesReceived</code>.
-                  <code>framesReceived - keyFramesReceived</code> gives you the number of delta
-                  frames received. This metric is incremented when the complete key frame is
-                  received. It is not incremented if a partial key frames is received and sent for
-                  decoding, i.e., the frame could not be recovered via retransmission or FEC.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -4246,6 +4246,42 @@ enum RTCNetworkType {
             </dd>
           </dl>
         </section>
+
+        <pre class="idl">partial dictionary RTCVideoSenderStats {
+          unsigned long keyFramesSent;
+};</pre>
+        <section>
+          <h2>Obsolete RTCVideoSenderStats members</h2>
+          <dl data-dfn-for="RTCVideoSenderStats">
+            <dt>
+              <dfn><code>keyFramesSent</code></dfn> of
+              type <span class="idlMemberType">unsigned long</span>
+            </dt>
+            <dd>
+              <p>
+                This field was replaced by keyFramesEncoded in RTCOutboundRtpStreamStats in June 2019. There were no known implementations supporting the old field at the time of the change.
+              </p>
+            </dd>
+          </dl>
+        </section>
+
+        <pre class="idl">partial dictionary RTCVideoReceiverStats {
+          unsigned long keyFramesReceived;
+};</pre>
+        <section>
+          <h2>Obsolete RTCVideoReceiverStats members</h2>
+          <dl data-dfn-for="RTCVideoReceiverStats">
+            <dt>
+              <dfn><code>keyFramesReceived</code></dfn> of
+              type <span class="idlMemberType">unsigned long</span>
+            </dt>
+            <dd>
+              <p>
+                This field was replaced by keyFramesDecoded in RTCInboundRtpStreamStats in June 2019. There were no known implementations supporting the old field at the time of the change.
+              </p>
+            </dd>
+          </dl>
+        </section>
       </div>
     </section>
     <section>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1520,6 +1520,7 @@ enum RTCStatsType {
              double               targetBitrate;
              unsigned long long   totalEncodedBytesTarget;
              unsigned long        framesEncoded;
+             unsigned long        keyFramesEncoded;
              unsigned long long   qpSum;
              double               totalEncodeTime;
              double               totalPacketSendDelay;
@@ -1639,6 +1640,18 @@ enum RTCStatsType {
                 <p>
                   Only valid for video. It represents the total number of frames successfully
                   encoded for this RTP media stream.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>keyFramesEncoded</code></dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  Only valid for video. It represents the total number of key frames, such as
+                  keyframes in VP8 [[RFC6386]] or IDR-frames in H.264 [[RFC6184]], successfully encoded for this RTP media stream.
+                  This is a subset of <code>framesEncoded</code>. <code>framesEncoded - keyFramesEncoded</code> gives
+                  you the number of delta frames encoded.
                 </p>
               </dd>
               <dt>
@@ -2392,7 +2405,6 @@ enum RTCStatsType {
              unsigned long       framesCaptured;
              unsigned long       framesSent;
              unsigned long       hugeFramesSent;
-             unsigned long       keyFramesSent;
 };</pre>
           <section>
             <h2>
@@ -2447,9 +2459,7 @@ enum RTCStatsType {
                   size of the frames. The average size of the frames is defined as the target
                   bitrate per second divided by the target fps at the time the frame was encoded.
                   These are usually complex to encode frames with a lot of changes in the picture.
-                  This can be used to estimate, e.g slide changes in the streamed presentation. If
-                  a huge frame is also a key frame, then both counters hugeFramesSent and
-                  keyFramesSent are incremented.
+                  This can be used to estimate, e.g slide changes in the streamed presentation.
                 </p>
                 <p>
                   The multiplier of 2.5 is choosen from analyzing encoded frame sizes for a sample
@@ -2457,19 +2467,6 @@ enum RTCStatsType {
                   multiplier which still caused all slide change events to be identified as a huge
                   frames. It, however, produced 1.4% of false positive slide change detections
                   which is deemed reasonable.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>keyFramesSent</code></dfn> of type <span class=
-                "idlMemberType">unsigned long</span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of key frames sent by this RTCRtpSender (or for this
-                  MediaStreamTrack, if <code>type</code> is <code>"track"</code>), such as
-                  Infra-frames in VP8 [[RFC6386]] or I-frames in H.264 [[RFC6184]]. This is a
-                  subset of <code>framesSent</code>. <code>framesSent - keyFramesSent</code> gives
-                  you the number of delta frames sent.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
Moving keyFramesSent on sender to keyFramesEncoded on outbound-rtp, as per offline discussion with @henbos.