### PR TITLE
Remove 'Contains' in a few places to improve consistency of each statstype description

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -575,7 +575,7 @@ enum RTCStatsType {
           </dt>
           <dd>
             <p>
-              Contains statistics related to a specific MediaStreamTrack's attachment to an
+              Statistics related to a specific MediaStreamTrack's attachment to an
               RTCRtpSender and the corresponding media-level metrics. It is accessed by either
               <code><a>RTCSenderVideoTrackAttachmentStats</a></code> or
               <code><a>RTCSenderAudioTrackAttachmentStats</a></code>, both inherited from
@@ -591,7 +591,7 @@ enum RTCStatsType {
           </dt>
           <dd>
             <p>
-              Contains statistics related to a specific RTCRtpSender and the corresponding
+              Statistics related to a specific RTCRtpSender and the corresponding
               media-level metrics. It is accessed by the <code><a>RTCAudioSenderStats</a></code> or
               the <code><a>RTCVideoSenderStats</a></code> depending on <code>kind</code>.
             </p>
@@ -601,7 +601,7 @@ enum RTCStatsType {
           </dt>
           <dd>
             <p>
-              Contains statistics related to a specific receiver and the corresponding media-level
+              Statistics related to a specific receiver and the corresponding media-level
               metrics. It is accessed by the <code><a>RTCAudioReceiverStats</a></code> or the
               <code><a>RTCVideoReceiverStats</a></code> depending on <code>kind</code>.
             </p>


### PR DESCRIPTION
Editorial changes.