### PR TITLE
Move "sender" stats to "outbound-rtp", "inbound-rtp" and "media-source"

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1150,6 +1150,9 @@ enum RTCStatsType {
              DOMString            remoteId;
              unsigned long        framesDecoded;
              unsigned long        keyFramesDecoded;
+             unsigned long        frameWidth;
+             unsigned long        frameHeight;
+             double               framesPerSecond;
              unsigned long long   qpSum;
              double               totalDecodeTime;
              DOMHighResTimeStamp  lastPacketReceivedTimestamp;
@@ -1220,6 +1223,38 @@ enum RTCStatsType {
                   decoded for this RTP media stream. This is a subset of
                   <code>framesDecoded</code>. <code>framesDecoded - keyFramesDecoded</code> gives
                   you the number of delta frames decoded.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>frameWidth</code></dfn> of type <span class="idlMemberType">unsigned
+                long</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the width of the last processed frame for this track. Before the first
+                  frame is processed this attribute is missing.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>frameHeight</code></dfn> of type <span class="idlMemberType">unsigned
+                long</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the height of the last processed frame for this track. Before the
+                  first frame is processed this attribute is missing.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>framesPerSecond</code></dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the nominal FPS value before the degradation preference is applied. It
+                  is the number of complete frames in the last second. For sending tracks it is the
+                  current captured FPS and for the receiving tracks it is the current decoding
+                  framerate.
                 </p>
               </dd>
               <dt>
@@ -1556,9 +1591,15 @@ enum RTCStatsType {
              unsigned long long   retransmittedBytesSent;
              double               targetBitrate;
              unsigned long long   totalEncodedBytesTarget;
+             unsigned long        frameWidth;
+             unsigned long        frameHeight;
+             double               framesPerSecond;
+             unsigned long        framesSent;
+             unsigned long        hugeFramesSent;
              unsigned long        framesEncoded;
              unsigned long        keyFramesEncoded;
              unsigned long long   qpSum;
+             unsigned long long   totalSamplesSent;
              double               totalEncodeTime;
              double               totalPacketSendDelay;
              double               averageRtcpInterval;
@@ -1670,6 +1711,70 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
+                <dfn><code>frameWidth</code></dfn> of type <span class="idlMemberType">unsigned
+                long</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the width of the last processed frame for this track. Before the first
+                  frame is processed this attribute is missing.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>frameHeight</code></dfn> of type <span class="idlMemberType">unsigned
+                long</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the height of the last processed frame for this track. Before the
+                  first frame is processed this attribute is missing.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>framesPerSecond</code></dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the nominal FPS value before the degradation preference is applied. It
+                  is the number of complete frames in the last second. For sending tracks it is the
+                  current captured FPS and for the receiving tracks it is the current decoding
+                  framerate.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>framesSent</code></dfn> of type <span class="idlMemberType">unsigned
+                long</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the total number of frames sent by this RTCRtpSender (or for this
+                  MediaStreamTrack, if <code>type</code> is <code>"track"</code>).
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>hugeFramesSent</code></dfn> of type <span class="idlMemberType">unsigned
+                long</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the total number of huge frames sent by this RTCRtpSender (or for this
+                  MediaStreamTrack, if <code>type</code> is <code>"track"</code>). Huge frames, by
+                  definition, are frames that have an encoded size at least 2.5 times the average
+                  size of the frames. The average size of the frames is defined as the target
+                  bitrate per second divided by the target fps at the time the frame was encoded.
+                  These are usually complex to encode frames with a lot of changes in the picture.
+                  This can be used to estimate, e.g slide changes in the streamed presentation.
+                </p>
+                <p>
+                  The multiplier of 2.5 is choosen from analyzing encoded frame sizes for a sample
+                  presentation using webrtc standalone implementation. 2.5 is a reasonably large
+                  multiplier which still caused all slide change events to be identified as a huge
+                  frames. It, however, produced 1.4% of false positive slide change detections
+                  which is deemed reasonable.
+                </p>
+              </dd>
+              <dt>
                 <dfn><code>framesEncoded</code></dfn> of type <span class=
                 "idlMemberType">long</span>
               </dt>
@@ -1710,6 +1815,15 @@ enum RTCStatsType {
                 <p>
                   Note that the QP value is only an indication of quantizer values used; many
                   formats have ways to vary the quantizer value within the frame.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>totalSamplesSent</code></dfn> of type <span class=
+                "idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  The total number of samples that have been sent by this sender.
                 </p>
               </dd>
               <dt>
@@ -2448,49 +2562,13 @@ enum RTCStatsType {
         </h3>
         <div>
           <pre class="idl">dictionary RTCVideoHandlerStats : RTCMediaHandlerStats {
-             unsigned long       frameWidth;
-             unsigned long       frameHeight;
-             double              framesPerSecond;
 };</pre>
           <section>
             <h2>
               Dictionary <a class="idlType">RTCVideoHandlerStats</a> Members
             </h2>
             <dl data-link-for="RTCVideoHandlerStats" data-dfn-for="RTCVideoHandlerStats" class=
-            "dictionary-members">
-              <dt>
-                <dfn><code>frameWidth</code></dfn> of type <span class="idlMemberType">unsigned
-                long</span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the width of the last processed frame for this track. Before the first
-                  frame is processed this attribute is missing.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>frameHeight</code></dfn> of type <span class="idlMemberType">unsigned
-                long</span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the height of the last processed frame for this track. Before the
-                  first frame is processed this attribute is missing.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>framesPerSecond</code></dfn> of type <span class=
-                "idlMemberType">double</span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the nominal FPS value before the degradation preference is applied. It
-                  is the number of complete frames in the last second. For sending tracks it is the
-                  current captured FPS and for the receiving tracks it is the current decoding
-                  framerate.
-                </p>
-              </dd>
-            </dl>
+            "dictionary-members"></dl>
           </section>
         </div>
       </section>
@@ -2509,9 +2587,6 @@ enum RTCStatsType {
         <div>
           <pre class="idl">dictionary RTCVideoSenderStats : RTCVideoHandlerStats {
              DOMString           mediaSourceId;
-             unsigned long       framesCaptured;
-             unsigned long       framesSent;
-             unsigned long       hugeFramesSent;
 };</pre>
           <section>
             <h2>
@@ -2527,54 +2602,6 @@ enum RTCStatsType {
                 <p>
                   The identifier of the stats object representing the track currently attached to
                   this sender, an <code><a>RTCMediaSourceStats</a></code>.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>framesCaptured</code></dfn> of type <span class="idlMemberType">unsigned
-                long</span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of frames captured, before encoding, for this
-                  RTCRtpSender (or for this MediaStreamTrack, if <code>type</code> is
-                  <code>"track"</code>). For example, if <code>type</code> is <code>"sender"</code>
-                  and this sender's track represents a camera, then this is the number of frames
-                  produced by the camera for this track while being sent by this sender, combined
-                  with the number of frames produced by all tracks previously attached to this
-                  sender while being sent by this sender. Framerates can vary due to hardware
-                  limitations or environmental factors such as lighting conditions.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>framesSent</code></dfn> of type <span class="idlMemberType">unsigned
-                long</span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of frames sent by this RTCRtpSender (or for this
-                  MediaStreamTrack, if <code>type</code> is <code>"track"</code>).
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>hugeFramesSent</code></dfn> of type <span class="idlMemberType">unsigned
-                long</span>
-              </dt>
-              <dd>
-                <p>
-                  Represents the total number of huge frames sent by this RTCRtpSender (or for this
-                  MediaStreamTrack, if <code>type</code> is <code>"track"</code>). Huge frames, by
-                  definition, are frames that have an encoded size at least 2.5 times the average
-                  size of the frames. The average size of the frames is defined as the target
-                  bitrate per second divided by the target fps at the time the frame was encoded.
-                  These are usually complex to encode frames with a lot of changes in the picture.
-                  This can be used to estimate, e.g slide changes in the streamed presentation.
-                </p>
-                <p>
-                  The multiplier of 2.5 is choosen from analyzing encoded frame sizes for a sample
-                  presentation using webrtc standalone implementation. 2.5 is a reasonably large
-                  multiplier which still caused all slide change events to be identified as a huge
-                  frames. It, however, produced 1.4% of false positive slide change detections
-                  which is deemed reasonable.
                 </p>
               </dd>
             </dl>
@@ -2751,7 +2778,7 @@ enum RTCStatsType {
         </h3>
         <div>
           <pre class="idl">dictionary RTCAudioHandlerStats : RTCMediaHandlerStats {
-             boolean             voiceActivityFlag;
+              boolean              voiceActivityFlag;
 };</pre>
           <section>
             <h2>
@@ -2796,7 +2823,6 @@ enum RTCStatsType {
              DOMString           mediaSourceId;
              double              echoReturnLoss;
              double              echoReturnLossEnhancement;
-             unsigned long long  totalSamplesSent;
 };</pre>
           <section>
             <h2>
@@ -2834,15 +2860,6 @@ enum RTCStatsType {
                   Only present while the sender is sending a track sourced from a microphone where
                   echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
                   (2012) section 3.15.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>totalSamplesSent</code></dfn> of type <span class=
-                "idlMemberType">unsigned long long</span>
-              </dt>
-              <dd>
-                <p>
-                  The total number of samples that have been sent by this sender.
                 </p>
               </dd>
             </dl>
@@ -4372,8 +4389,74 @@ enum RTCNetworkType {
             </dd>
           </dl>
         </section>
+        <pre class="idl">partial dictionary RTCAudioSenderStats : RTCAudioHandlerStats {
+            unsigned long long  totalSamplesSent;
+};</pre>
+        <section>
+          <h2>
+            Obsolete RTCAudioSenderStats members
+          </h2>
+          <dl data-link-for="RTCAudioSenderStats" data-dfn-for="RTCAudioSenderStats" class=
+          "dictionary-members">
+            <dt>
+              <dfn><code>totalSamplesSent</code></dfn> of type <span class=
+              "idlMemberType">unsigned long long</span>
+            </dt>
+            <dd>
+              <p>
+                This was moved to RTCOutboundRtpStreamStats in July, 2019.
+              </p>
+            </dd>
+          </dl>
+        </section>
+        <pre class="idl">partial dictionary RTCVideoHandlerStats : RTCMediaHandlerStats {
+          unsigned long frameWidth;
+          unsigned long frameHeight;
+          double        framesPerSecond;
+};</pre>
+        <section>
+          <h2>
+            Obsolete RTCVideoHandlerStats members
+          </h2>
+          <dl data-link-for="RTCVideoHandlerStats" data-dfn-for="RTCVideoHandlerStats" class=
+          "dictionary-members">
+            <dt>
+              <dfn><code>frameWidth</code></dfn> of type <span class="idlMemberType">unsigned
+              long</span>
+            </dt>
+            <dd>
+              <p>
+                This was moved to RTCOutboundRtpStreamStats and
+                RTCInboundRtpStreamStats in July, 2019.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>frameHeight</code></dfn> of type <span class="idlMemberType">unsigned
+              long</span>
+            </dt>
+            <dd>
+              <p>
+                This was moved to RTCOutboundRtpStreamStats and
+                RTCInboundRtpStreamStats in July, 2019.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>framesPerSecond</code></dfn> of type <span class=
+              "idlMemberType">double</span>
+            </dt>
+            <dd>
+              <p>
+                This was moved to RTCOutboundRtpStreamStats and
+                RTCInboundRtpStreamStats in July, 2019.
+              </p>
+            </dd>
+          </dl>
+        </section>
         <pre class="idl">partial dictionary RTCVideoSenderStats {
           unsigned long keyFramesSent;
+          unsigned long framesCaptured;
+          unsigned long framesSent;
+          unsigned long hugeFramesSent;
 };</pre>
         <section>
           <h2>
@@ -4389,6 +4472,33 @@ enum RTCNetworkType {
                 This field was replaced by keyFramesEncoded in RTCOutboundRtpStreamStats in June
                 2019. There were no known implementations supporting the old field at the time of
                 the change.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>framesCaptured</code></dfn> of type <span class="idlMemberType">unsigned
+              long</span>
+            </dt>
+            <dd>
+              <p>
+                This was replaced by RTCVideoSourceStats.frames in May, 2019.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>framesSent</code></dfn> of type <span class="idlMemberType">unsigned
+              long</span>
+            </dt>
+            <dd>
+              <p>
+                This was moved to RTCOutboundRtpStreamStats in July, 2019.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>hugeFramesSent</code></dfn> of type <span class="idlMemberType">unsigned
+              long</span>
+            </dt>
+            <dd>
+              <p>
+                This was moved to RTCOutboundRtpStreamStats in July, 2019.
               </p>
             </dd>
           </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1155,6 +1155,7 @@ enum RTCStatsType {
              double               framesPerSecond;
              unsigned long long   qpSum;
              double               totalDecodeTime;
+             boolean              voiceActivityFlag;
              DOMHighResTimeStamp  lastPacketReceivedTimestamp;
              double               averageRtcpInterval;
              unsigned long        fecPacketsReceived;
@@ -1288,6 +1289,22 @@ enum RTCStatsType {
                   value with <a>framesDecoded</a>. The time it takes to decode one frame is the
                   time passed between feeding the decoder a frame and the decoder returning decoded
                   data for that frame.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>voiceActivityFlag</code></dfn> of type <span class=
+                "idlMemberType">boolean</span>
+              </dt>
+              <dd>
+                <p>
+                  Whether the last RTP packet sent or played out by this track contained voice
+                  activity or not based on the presence of the V bit in the extension header, as
+                  defined in [[RFC6464]].
+                </p>
+                <p>
+                  This value indicates the voice activity in the latest RTP packet played out from
+                  a given SSRC, and is defined in the
+                  <code>RTCRtpSynchronizationSource.voiceActivityFlag</code> of [[WEBRTC].
                 </p>
               </dd>
               <dt>
@@ -1600,6 +1617,7 @@ enum RTCStatsType {
              unsigned long        keyFramesEncoded;
              unsigned long long   qpSum;
              unsigned long long   totalSamplesSent;
+             boolean              voiceActivityFlag;
              double               totalEncodeTime;
              double               totalPacketSendDelay;
              double               averageRtcpInterval;
@@ -1824,6 +1842,22 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The total number of samples that have been sent by this sender.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>voiceActivityFlag</code></dfn> of type <span class=
+                "idlMemberType">boolean</span>
+              </dt>
+              <dd>
+                <p>
+                  Whether the last RTP packet sent or played out by this track contained voice
+                  activity or not based on the presence of the V bit in the extension header, as
+                  defined in [[RFC6464]].
+                </p>
+                <p>
+                  This value indicates the voice activity in the latest RTP packet played out from
+                  a given SSRC, and is defined in the
+                  <code>RTCRtpSynchronizationSource.voiceActivityFlag</code> of [[WEBRTC].
                 </p>
               </dd>
               <dt>
@@ -2778,7 +2812,6 @@ enum RTCStatsType {
         </h3>
         <div>
           <pre class="idl">dictionary RTCAudioHandlerStats : RTCMediaHandlerStats {
-              boolean              voiceActivityFlag;
 };</pre>
           <section>
             <h2>
@@ -2786,22 +2819,6 @@ enum RTCStatsType {
             </h2>
             <dl data-link-for="RTCAudioHandlerStats" data-dfn-for="RTCAudioHandlerStats" class=
             "dictionary-members">
-              <dt>
-                <dfn><code>voiceActivityFlag</code></dfn> of type <span class=
-                "idlMemberType">boolean</span>
-              </dt>
-              <dd>
-                <p>
-                  Whether the last RTP packet sent or played out by this track contained voice
-                  activity or not based on the presence of the V bit in the extension header, as
-                  defined in [[RFC6464]].
-                </p>
-                <p>
-                  This value indicates the voice activity in the latest RTP packet played out from
-                  a given SSRC, and is defined in the
-                  <code>RTCRtpSynchronizationSource.voiceActivityFlag</code> of [[WEBRTC].
-                </p>
-              </dd>
             </dl>
           </section>
         </div>
@@ -4355,6 +4372,7 @@ enum RTCNetworkType {
             double              audioLevel;
             double              totalAudioEnergy;
             double              totalSamplesDuration;
+            boolean             voiceActivityFlag;
 };</pre>
         <section>
           <h2>
@@ -4366,7 +4384,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in June 2019.
+                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in August, 2019.
               </p>
             </dd>
             <dt>
@@ -4375,7 +4393,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in June 2019.
+                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in August, 2019.
               </p>
             </dd>
             <dt>
@@ -4384,7 +4402,16 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in June 2019.
+                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in August, 2019.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>voiceActivityFlag</code></dfn> of type <span class=
+              "idlMemberType">boolean</span>
+            </dt>
+            <dd>
+              <p>
+                This field was moved to RTCOutboundRtpStreamStats and RTCInboundRtpStreamStats in August, 2019.
               </p>
             </dd>
           </dl>
@@ -4404,7 +4431,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This was moved to RTCOutboundRtpStreamStats in July, 2019.
+                This was moved to RTCOutboundRtpStreamStats in August, 2019.
               </p>
             </dd>
           </dl>
@@ -4427,7 +4454,7 @@ enum RTCNetworkType {
             <dd>
               <p>
                 This was moved to RTCOutboundRtpStreamStats and
-                RTCInboundRtpStreamStats in July, 2019.
+                RTCInboundRtpStreamStats in August, 2019.
               </p>
             </dd>
             <dt>
@@ -4437,7 +4464,7 @@ enum RTCNetworkType {
             <dd>
               <p>
                 This was moved to RTCOutboundRtpStreamStats and
-                RTCInboundRtpStreamStats in July, 2019.
+                RTCInboundRtpStreamStats in August, 2019.
               </p>
             </dd>
             <dt>
@@ -4447,7 +4474,7 @@ enum RTCNetworkType {
             <dd>
               <p>
                 This was moved to RTCOutboundRtpStreamStats and
-                RTCInboundRtpStreamStats in July, 2019.
+                RTCInboundRtpStreamStats in August, 2019.
               </p>
             </dd>
           </dl>
@@ -4489,7 +4516,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This was moved to RTCOutboundRtpStreamStats in July, 2019.
+                This was moved to RTCOutboundRtpStreamStats in August, 2019.
               </p>
             </dd>
             <dt>
@@ -4498,7 +4525,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This was moved to RTCOutboundRtpStreamStats in July, 2019.
+                This was moved to RTCOutboundRtpStreamStats in August, 2019.
               </p>
             </dd>
           </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2179,6 +2179,8 @@ enum RTCStatsType {
               double              audioLevel;
               double              totalAudioEnergy;
               double              totalSamplesDuration;
+              double              echoReturnLoss;
+              double              echoReturnLossEnhancement;
 };</pre>
           <section>
             <h2>
@@ -2257,6 +2259,28 @@ enum RTCStatsType {
                   by this source for the lifetime of this stats object. Can be used with
                   <code><a>totalAudioEnergy</a></code> to compute an average audio level over
                   different intervals.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>echoReturnLoss</code></dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  Only present while the sender is sending a track sourced from a microphone where
+                  echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
+                  (2012) section 3.14.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>echoReturnLossEnhancement</code></dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  Only present while the sender is sending a track sourced from a microphone where
+                  echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
+                  (2012) section 3.15.
                 </p>
               </dd>
             </dl>
@@ -2838,8 +2862,6 @@ enum RTCStatsType {
         <div>
           <pre class="idl">dictionary RTCAudioSenderStats : RTCAudioHandlerStats {
              DOMString           mediaSourceId;
-             double              echoReturnLoss;
-             double              echoReturnLossEnhancement;
 };</pre>
           <section>
             <h2>
@@ -2855,28 +2877,6 @@ enum RTCStatsType {
                 <p>
                   The identifier of the stats object representing the track currently attached to
                   this sender, an <code><a>RTCMediaSourceStats</a></code>.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>echoReturnLoss</code></dfn> of type <span class=
-                "idlMemberType">double</span>
-              </dt>
-              <dd>
-                <p>
-                  Only present while the sender is sending a track sourced from a microphone where
-                  echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
-                  (2012) section 3.14.
-                </p>
-              </dd>
-              <dt>
-                <dfn><code>echoReturnLossEnhancement</code></dfn> of type <span class=
-                "idlMemberType">double</span>
-              </dt>
-              <dd>
-                <p>
-                  Only present while the sender is sending a track sourced from a microphone where
-                  echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
-                  (2012) section 3.15.
                 </p>
               </dd>
             </dl>
@@ -4384,7 +4384,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in August, 2019.
+                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in June 2019.
               </p>
             </dd>
             <dt>
@@ -4393,7 +4393,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in August, 2019.
+                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in June 2019.
               </p>
             </dd>
             <dt>
@@ -4402,7 +4402,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in August, 2019.
+                This field was moved to RTCAudioReceiverStats and RTCAudioSourceStats in June 2019.
               </p>
             </dd>
             <dt>
@@ -4411,13 +4411,15 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This field was moved to RTCOutboundRtpStreamStats and RTCInboundRtpStreamStats in August, 2019.
+                This field was moved to RTCOutboundRtpStreamStats and RTCInboundRtpStreamStats in August 2019.
               </p>
             </dd>
           </dl>
         </section>
         <pre class="idl">partial dictionary RTCAudioSenderStats : RTCAudioHandlerStats {
             unsigned long long  totalSamplesSent;
+            double              echoReturnLoss;
+            double              echoReturnLossEnhancement;
 };</pre>
         <section>
           <h2>
@@ -4431,7 +4433,25 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This was moved to RTCOutboundRtpStreamStats in August, 2019.
+                This was moved to RTCOutboundRtpStreamStats in August 2019.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>echoReturnLoss</code></dfn> of type <span class=
+              "idlMemberType">double</span>
+            </dt>
+            <dd>
+              <p>
+                This was moved to RTCAudioSourceStats in August 2019.
+              </p>
+            </dd>
+            <dt>
+              <dfn><code>echoReturnLossEnhancement</code></dfn> of type <span class=
+              "idlMemberType">double</span>
+            </dt>
+            <dd>
+              <p>
+                This was moved to RTCAudioSourceStats in August 2019.
               </p>
             </dd>
           </dl>
@@ -4454,7 +4474,7 @@ enum RTCNetworkType {
             <dd>
               <p>
                 This was moved to RTCOutboundRtpStreamStats and
-                RTCInboundRtpStreamStats in August, 2019.
+                RTCInboundRtpStreamStats in August 2019.
               </p>
             </dd>
             <dt>
@@ -4464,7 +4484,7 @@ enum RTCNetworkType {
             <dd>
               <p>
                 This was moved to RTCOutboundRtpStreamStats and
-                RTCInboundRtpStreamStats in August, 2019.
+                RTCInboundRtpStreamStats in August 2019.
               </p>
             </dd>
             <dt>
@@ -4474,7 +4494,7 @@ enum RTCNetworkType {
             <dd>
               <p>
                 This was moved to RTCOutboundRtpStreamStats and
-                RTCInboundRtpStreamStats in August, 2019.
+                RTCInboundRtpStreamStats in August 2019.
               </p>
             </dd>
           </dl>
@@ -4507,7 +4527,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This was replaced by RTCVideoSourceStats.frames in May, 2019.
+                This was replaced by RTCVideoSourceStats.frames in May 2019.
               </p>
             </dd>
             <dt>
@@ -4516,7 +4536,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This was moved to RTCOutboundRtpStreamStats in August, 2019.
+                This was moved to RTCOutboundRtpStreamStats in August 2019.
               </p>
             </dd>
             <dt>
@@ -4525,7 +4545,7 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This was moved to RTCOutboundRtpStreamStats in August, 2019.
+                This was moved to RTCOutboundRtpStreamStats in August 2019.
               </p>
             </dd>
           </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1232,8 +1232,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the width of the last processed frame for this track. Before the first
-                  frame is processed this attribute is missing.
+                  Only valid for video. Represents the width of the last decoded frame. Before the
+                  first frame is decoded this attribute is missing.
                 </p>
               </dd>
               <dt>
@@ -1242,8 +1242,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the height of the last processed frame for this track. Before the
-                  first frame is processed this attribute is missing.
+                  Only valid for video. Represents the height of the last decoded frame. Before
+                  the first frame is decoded this attribute is missing.
                 </p>
               </dd>
               <dt>
@@ -1252,10 +1252,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the nominal FPS value before the degradation preference is applied. It
-                  is the number of complete frames in the last second. For sending tracks it is the
-                  current captured FPS and for the receiving tracks it is the current decoding
-                  framerate.
+                  Only valid for video. The number of decoded frames in the last second.
                 </p>
               </dd>
               <dt>
@@ -1297,14 +1294,11 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Whether the last RTP packet sent or played out by this track contained voice
-                  activity or not based on the presence of the V bit in the extension header, as
-                  defined in [[RFC6464]].
-                </p>
-                <p>
-                  This value indicates the voice activity in the latest RTP packet played out from
-                  a given SSRC, and is defined in the
-                  <code>RTCRtpSynchronizationSource.voiceActivityFlag</code> of [[WEBRTC].
+                  Only valid for audio. Whether the last RTP packet whose frame was delivered to the
+                  RTCRtpReceiver's MediaStreamTrack for playout contained voice activity or not based
+                  on the presence of the V bit in the extension header, as defined in [[RFC6464]]. This
+                  is the stats-equivalent of <code>RTCRtpSynchronizationSource.voiceActivityFlag</code>
+                  in [[WEBRTC].
                 </p>
               </dd>
               <dt>
@@ -1734,8 +1728,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the width of the last processed frame for this track. Before the first
-                  frame is processed this attribute is missing.
+                  Only valid for video. Represents the width of the last encoded frame. The resolution
+                  of the encoded frame may be lower than the media source (see RTCVideoSourceStats.width).
+                  Before the first frame is encoded this attribute is missing.
                 </p>
               </dd>
               <dt>
@@ -1744,8 +1739,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the height of the last processed frame for this track. Before the
-                  first frame is processed this attribute is missing.
+                  Only valid for video. Represents the height of the last encoded frame. The resolution
+                  of the encoded frame may be lower than the media source (see RTCVideoSourceStats.height).
+                  Before the first frame is encoded this attribute is missing.
                 </p>
               </dd>
               <dt>
@@ -1754,10 +1750,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the nominal FPS value before the degradation preference is applied. It
-                  is the number of complete frames in the last second. For sending tracks it is the
-                  current captured FPS and for the receiving tracks it is the current decoding
-                  framerate.
+                  Only valid for video. The number of encoded frames during the last second. This may be
+                  lower than the media source frame rate (see RTCVideoSourceStats.framesPerSecond).
                 </p>
               </dd>
               <dt>
@@ -1766,8 +1760,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the total number of frames sent by this RTCRtpSender (or for this
-                  MediaStreamTrack, if <code>type</code> is <code>"track"</code>).
+                  Only valid for video. Represents the total number of frames sent on this RTP stream.
                 </p>
               </dd>
               <dt>
@@ -1776,17 +1769,16 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the total number of huge frames sent by this RTCRtpSender (or for this
-                  MediaStreamTrack, if <code>type</code> is <code>"track"</code>). Huge frames, by
-                  definition, are frames that have an encoded size at least 2.5 times the average
-                  size of the frames. The average size of the frames is defined as the target
-                  bitrate per second divided by the target fps at the time the frame was encoded.
-                  These are usually complex to encode frames with a lot of changes in the picture.
-                  This can be used to estimate, e.g slide changes in the streamed presentation.
+                  Only valid for video. Represents the total number of huge frames sent by this RTP
+                  stream. Huge frames, by definition, are frames that have an encoded size at least
+                  2.5 times the average size of the frames. The average size of the frames is defined
+                  as the target bitrate per second divided by the target FPS at the time the frame was
+                  encoded. These are usually complex to encode frames with a lot of changes in the
+                  picture. This can be used to estimate, e.g slide changes in the streamed presentation.
                 </p>
                 <p>
                   The multiplier of 2.5 is choosen from analyzing encoded frame sizes for a sample
-                  presentation using webrtc standalone implementation. 2.5 is a reasonably large
+                  presentation using WebRTC standalone implementation. 2.5 is a reasonably large
                   multiplier which still caused all slide change events to be identified as a huge
                   frames. It, however, produced 1.4% of false positive slide change detections
                   which is deemed reasonable.
@@ -1841,7 +1833,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The total number of samples that have been sent by this sender.
+                  Only valid for audio. The total number of samples that have been sent over this
+                  RTP stream.
                 </p>
               </dd>
               <dt>
@@ -1850,14 +1843,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Whether the last RTP packet sent or played out by this track contained voice
-                  activity or not based on the presence of the V bit in the extension header, as
-                  defined in [[RFC6464]].
-                </p>
-                <p>
-                  This value indicates the voice activity in the latest RTP packet played out from
-                  a given SSRC, and is defined in the
-                  <code>RTCRtpSynchronizationSource.voiceActivityFlag</code> of [[WEBRTC].
+                  Only valid for audio. Whether the last RTP packet sent contained voice activity
+                  or not based on the presence of the V bit in the extension header, as defined in
+                  [[RFC6464]].
                 </p>
               </dd>
               <dt>
@@ -2267,7 +2255,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only present while the sender is sending a track sourced from a microphone where
+                  Only present when the MediaStreamTrack is sourced from a microphone where
                   echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
                   (2012) section 3.14.
                 </p>
@@ -2278,7 +2266,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only present while the sender is sending a track sourced from a microphone where
+                  Only present when the MediaStreamTrack is sourced from a microphone where
                   echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
                   (2012) section 3.15.
                 </p>
@@ -4493,8 +4481,12 @@ enum RTCNetworkType {
             </dt>
             <dd>
               <p>
-                This was moved to RTCOutboundRtpStreamStats and
-                RTCInboundRtpStreamStats in August 2019.
+                For the sending case, this was replaced by RTCVideoSourceStats.framesPerSecond
+                in May 2019 representing the frame rate of the track. For the receiving case,
+                this was moved to RTCInboundRtpStreamStats in August 2019 representing the
+                decoding frame rate. In August 2019, framesPerSecond was also added to
+                RTCOutboundRtpStreamStats, representing the encoding frame rate (which may be
+                lower than the source frame rate).
               </p>
             </dd>
           </dl>


### PR DESCRIPTION
Partial fix for #402.

The following stats have been moved:

**RTCVideoHandlerStats**
- frameWidth, frameHeight: Moved to RTCOutboundRtpStreamStats and RTCInboundRtpStreamStats represending encoded and decoded frames.
- framesPerSecond: For source stats, we already have RTCVideoSourceStats.framesPerSecond (i.e. camera FPS). In this PR framesPerSecond was added to RTCOutboundRtpStreamStats, but representing the encoding frame rate, which previously did not exist. For the receiving case, this was moved to RTCInboundRtpStreamStats representing the decoding frame rate.

**RTCVideoSenderStats**
- framesCaptured: Obsolete. We already have RTCMediaSourceStats.frames.
- framesSent, hugeFramesSent: Moved to RTCOutboundRtpStreamStats.

**RTCAudioHandlerStats**
- voiceActivityFlag: This was moved to RTCOutboundRtpStreamStats and RTCInboundRtpStreamStats. The definition was clarified to be the same as for RTCRtpReceiver.getSynchronizationSources() for the inbound case. For the outbound case, there is no webrtc-pc equivalent way of obtaining this information, so it is defined as the V-bit of the last sent packet.

**RTCAudioSenderStats**
- totalSamplesSent: Moved to RTCOutboundRtpStreamStats.
- echoReturnLoss, echoReturnLossEnhancement: Moved to RTCAudioSourceStats.

This PR moves metrics that that apply to both sending and receiving, and moves all the sending metrics. A follow-up PR will take care of moving receiving-only metrics to RTCInboundRtpStreamStats.