### PR TITLE
Revert "Remove RTCIceCandidateStats deleted property (#462)"

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3401,6 +3401,7 @@ enum RTCStatsType {
              long                     priority;
              DOMString                url;
              DOMString                relayProtocol;
+             boolean                  deleted = false;
 };</pre>
           <section>
             <h2>
@@ -3519,6 +3520,22 @@ enum RTCStatsType {
                   was obtained. It is the same as the <a href=
                   "https://w3c.github.io/webrtc-pc/#rtcpeerconnectioniceevent">url surfaced in the
                   RTCPeerConnectionIceEvent</a>.
+                </p>
+                <p>
+                  For remote candidates, this property is not present.
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>deleted</code></dfn> of type <span class="idlMemberType">boolean</span>,
+                defaulting to <code>false</code>
+              </dt>
+              <dd>
+                <p>
+                  For local candidates, <code>true</code> indicates that the candidate has been
+                  deleted/freed as described by [[!RFC5245]]. For host candidates, this means that
+                  any network resources (typically a socket) associated with the candidate have
+                  been released. For TURN candidates, this means the TURN allocation is no longer
+                  active.
                 </p>
                 <p>
                   For remote candidates, this property is not present.


### PR DESCRIPTION
This reverts commit 4244214fd04a23b841e87b8693de9d1d7e18e925.

@youennf could you add the stat to the obsolete section