### PR TITLE
Add RTCTransportStats.selectedCandidatePairChanges

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3211,6 +3211,7 @@ enum RTCStatsType {
              DOMString             dtlsCipher;
              DOMString             srtpCipher;
              DOMString             tlsGroup;
+             unsigned long         selectedCandidatePairChanges;
 };</pre>
           <section>
             <h2>
@@ -3360,6 +3361,16 @@ enum RTCStatsType {
                   Descriptive name of the group used for the encryption, as defined in the
                   "Description" column of the IANA TLS Supported Groups registry
                   [[!IANA-TLS-GROUPS]].
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>selectedCandidatePairChanges</code></dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  The number of times that the selected candidate pair of this transport has
+                  changed.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3370,7 +3370,10 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The number of times that the selected candidate pair of this transport has
-                  changed.
+                  changed. Going from not having a selected candidate pair to having a
+                  selected candidate pair, or the other way around, also increases this
+                  counter. It is initially zero and becomes one when an initial candidate
+                  pair is selected.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
Fixes #474

This can happen due to ICE restarts or it can happen spontaneously if continuous renomination (extension spec) is supported. A higher count in selected candidate pair changes (ICE reroutes) may correlate with worse quality.