### PR TITLE
Added note about channels for all sample based metrics

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1519,6 +1519,12 @@ enum RTCStatsType {
                   delay can be calculated by dividing the <code>jitterBufferDelay</code> with the
                   <code>jitterBufferEmittedCount</code>.
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
+                </p>
               </dd>
               <dt>
                 <dfn><code>jitterBufferEmittedCount</code></dfn> of type <span class=
@@ -1529,6 +1535,12 @@ enum RTCStatsType {
                   The total number of audio samples or video frames that have come out of the
                   jitter buffer (increasing <code>jitterBufferDelay</code>).
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
+                </p>
               </dd>
               <dt>
                 <dfn><code>totalSamplesReceived</code></dfn> of type <span class=
@@ -1538,6 +1550,12 @@ enum RTCStatsType {
                 <p>
                   Only valid for audio. The total number of samples that have been received on this
                   RTP stream. This includes <a>concealedSamples</a>.
+                </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
                 </p>
               </dd>
               <dt>
@@ -1554,6 +1572,12 @@ enum RTCStatsType {
                   too late to be played out (reported in <a data-link-for=
                   "RTCReceivedRtpStreamStats">packetsDiscarded</a>).
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
+                </p>
               </dd>
               <dt>
                 <dfn><code>silentConcealedSamples</code></dfn> of type <span class=
@@ -1564,6 +1588,12 @@ enum RTCStatsType {
                   Only valid for audio. The total number of concealed samples inserted that are
                   "silent". Playing out silent samples results in silence or comfort noise. This is
                   a subset of <a>concealedSamples</a>.
+                </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
                 </p>
               </dd>
               <dt>
@@ -1577,6 +1607,12 @@ enum RTCStatsType {
                   consecutive concealed samples will increase the <a>concealedSamples</a> count multiple
                   times but is a single concealment event.
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
+                </p>
               </dd>
               <dt>
                 <dfn><code>insertedSamplesForDeceleration</code></dfn> of type <span class=
@@ -1589,6 +1625,12 @@ enum RTCStatsType {
                   If playout is slowed down by inserting samples, this will be the number of inserted
                   samples.
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
+                </p>
               </dd>
               <dt>
                 <dfn><code>removedSamplesForAcceleration</code></dfn> of type <span class=
@@ -1600,6 +1642,12 @@ enum RTCStatsType {
                   difference between the number of samples received and the number of samples played
                   out. If speedup is achieved by removing samples, this will be the count of samples
                   removed.
+                </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
                 </p>
               </dd>
               <dt>
@@ -1660,6 +1708,14 @@ enum RTCStatsType {
                   <code>Math.sqrt(0.0026/0.02) = 0.36</code>, which is the same value that would be
                   obtained by doing an RMS calculation over the contiguous 20ms segment of audio.
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample. The
+                  "audio energy of a sample" refers to the highest energy of any
+                  channel.
+                </p>
               </dd>
               <dt>
                 <dfn><code>totalSamplesDuration</code></dfn> of type <span class=
@@ -1676,6 +1732,12 @@ enum RTCStatsType {
                   (and thus counted by <code><a>totalSamplesReceived</a></code>). Can be used with
                   <code><a>totalAudioEnergy</a></code> to compute an average audio level over
                   different intervals.
+                </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
                 </p>
               </dd>
               <dt>
@@ -2146,6 +2208,12 @@ enum RTCStatsType {
                   Only valid for audio. The total number of samples that have been sent over this
                   RTP stream.
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
+                </p>
               </dd>
               <dt>
                 <dfn><code>voiceActivityFlag</code></dfn> of type <span class=
@@ -2580,6 +2648,14 @@ enum RTCStatsType {
                   <code>Math.sqrt(0.0026/0.02) = 0.36</code>, which is the same value that would be
                   obtained by doing an RMS calculation over the contiguous 20ms segment of audio.
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample. The
+                  "audio energy of a sample" refers to the highest energy of any
+                  channel.
+                </p>
               </dd>
               <dt>
                 <dfn><code>totalSamplesDuration</code></dfn> of type <span class=
@@ -2596,6 +2672,12 @@ enum RTCStatsType {
                   <code><a>totalAudioEnergy</a></code> to compute an average audio level over
                   different intervals.
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample.
+                </p>
               </dd>
               <dt>
                 <dfn><code>echoReturnLoss</code></dfn> of type <span class=
@@ -2607,6 +2689,14 @@ enum RTCStatsType {
                   echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
                   (2012) section 3.14.
                 </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample. When
+                  calculating echo return loss, the channel of the least audio
+                  energy is considered for any sample.
+                </p>
               </dd>
               <dt>
                 <dfn><code>echoReturnLossEnhancement</code></dfn> of type <span class=
@@ -2617,6 +2707,14 @@ enum RTCStatsType {
                   Only present when the MediaStreamTrack is sourced from a microphone where
                   echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
                   (2012) section 3.15.
+                </p>
+                <p>
+                  Note: If multiple audio channels are used, metrics based on
+                  samples do not increment at a higher rate. "A sample" refers
+                  to having a sample in either channel - simultaneously having
+                  samples in multiple channels counts as a single sample. When
+                  calculating echo return loss enhancement, the channel of the
+                  least audio energy is considered for any sample.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
Fixes #448.

Alternatively we could avoid copy-pasting the same paragraph all over the places by defining this once in the beginning of the document, perhaps that is preferred, what do you think?