### PR TITLE
Add RTCTransportStats.iceUfrag

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3286,6 +3286,7 @@ enum RTCStatsType {
              unsigned long long    bytesReceived;
              DOMString             rtcpTransportStatsId;
              RTCIceRole            iceRole;
+             DOMString             iceUfrag;
              RTCDtlsTransportState dtlsState;
              DOMString             selectedCandidatePairId;
              DOMString             localCertificateId;
@@ -3359,6 +3360,17 @@ enum RTCStatsType {
                 <p>
                   Set to the current value of the "role" attribute of the underlying
                   RTCDtlsTransport's "transport".
+                </p>
+              </dd>
+              <dt>
+                <dfn><code>iceUfrag</code></dfn> of type <span class=
+                "idlMemberType"><a>DOMString</a></span>
+              </dt>
+              <dd>
+                <p>
+                  Set to the current ufrag value of the underlying transport.
+                  This can be used to identify which ICE generation associated
+                  ICE candidates belong to.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Fixes #358.
However, we might still want to discuss whether or not a candidate generated twice with the same ip is to be considered for the same monitored object or not. Should I file an issue?