### PR TITLE
Remove CSS WebIDL prefix

### DIFF
--- a/webrtc-stats.css
+++ b/webrtc-stats.css
@@ -196,18 +196,6 @@ pre.idl {
     line-height:    120%;
 }
 
-pre.idl::before {
-    content:    "WebIDL";
-    display:    block;
-    width:      150px;
-    background: #90b8de;
-    color:  #fff;
-    font-family:    initial;
-    padding:    3px;
-    font-weight:    bold;
-    margin: -1em 0 1em -1em;
-}
-
 .idlType {
     color:  #ff4500;
     font-weight:    bold;


### PR DESCRIPTION

![2xwebidl](https://user-images.githubusercontent.com/216410/73722862-ca352a80-4727-11ea-8be9-1d301c0582b0.png)
Redundants with ReSpec-provided text