### PR TITLE
Mark some stats as only 'present' rather than 'valid' for some type o…

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -64,11 +64,11 @@
       </p>
       <ul>
         <li>An implementation MUST support generating statistics for the type
-        {{RTCInboundRtpStreamStats}}, with attributes {{RTCReceivedRtpStreamStats/packetsReceived}}, {{RTCInboundRtpStreamStats/bytesReceived}}, {{RTCReceivedRtpStreamStats/packetsLost}}, and
+        {{RTCInboundRtpStreamStats}}, with members {{RTCReceivedRtpStreamStats/packetsReceived}}, {{RTCInboundRtpStreamStats/bytesReceived}}, {{RTCReceivedRtpStreamStats/packetsLost}}, and
         {{RTCReceivedRtpStreamStats/jitter}}.
         </li>
         <li>It MUST support generating statistics for the type {{RTCOutboundRtpStreamStats}}, with
-        attributes {{RTCSentRtpStreamStats/packetsSent}}, {{RTCSentRtpStreamStats/bytesSent}}.
+        members {{RTCSentRtpStreamStats/packetsSent}}, {{RTCSentRtpStreamStats/bytesSent}}.
         </li>
         <li>For all subclasses of {{RTCRtpStreamStats}}, it MUST include {{RTCRtpStreamStats/ssrc}} and {{RTCRtpStreamStats/kind}}. When stats
         exist for both sides of a connection, in the form of an {{RTCStatsType/"inbound-rtp"}} / {{RTCStatsType/"remote-outbound-rtp"}}
@@ -138,8 +138,8 @@
             are represented by a {{DOMString}} containing <var>id</var> value of the referenced stats object.
           </p>
           <p>
-            All stats object references have type {{DOMString}} and attribute names ending in <code>Id</code>, or
-            they have type <code>sequence&lt;{{DOMString}}&gt;</code> and attribute names ending in <code>Ids</code>.
+            All stats object references have type {{DOMString}} and member names ending in <code>Id</code>, or
+            they have type <code>sequence&lt;{{DOMString}}&gt;</code> and member names ending in <code>Ids</code>.
           </p>
         </dd>
         <dt>
@@ -1267,7 +1267,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Only [=dictionary member/present=] for video. Represents the width of the last decoded frame. Before the
-                  first frame is decoded this attribute is missing.
+                  first frame is decoded this member is [=dictionary member/not present=].
                 </p>
               </dd>
               <dt>
@@ -1277,7 +1277,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Only [=dictionary member/present=] for video. Represents the height of the last decoded frame. Before
-                  the first frame is decoded this attribute is missing.
+                  the first frame is decoded this member is [=dictionary member/not present=].
                 </p>
               </dd>
               <dt>
@@ -1288,7 +1288,7 @@ enum RTCStatsType {
                 <p>
                   Only [=dictionary member/present=] for video. Represents the bit depth per pixel of the last decoded frame.
                   Typical values are 24, 30, or 36 bits.
-                  Before the first frame is decoded this attribute is missing.
+                  Before the first frame is decoded this member is [=dictionary member/not present=].
                 </p>
               </dd>
               <dt>
@@ -2126,7 +2126,7 @@ enum RTCStatsType {
                 <p>
                   Only [=dictionary member/present=] for video. Represents the width of the last encoded frame. The resolution
                   of the encoded frame may be lower than the media source (see {{RTCVideoSourceStats.width}}).
-                  Before the first frame is encoded this attribute is missing.
+                  Before the first frame is encoded this member is [=dictionary member/not present=].
                 </p>
               </dd>
               <dt>
@@ -2137,7 +2137,7 @@ enum RTCStatsType {
                 <p>
                   Only [=dictionary member/present=] for video. Represents the height of the last encoded frame. The resolution
                   of the encoded frame may be lower than the media source (see {{RTCVideoSourceStats.height}}).
-                  Before the first frame is encoded this attribute is missing.
+                  Before the first frame is encoded this member is [=dictionary member/not present=].
                 </p>
               </dd>
               <dt>
@@ -2148,7 +2148,7 @@ enum RTCStatsType {
                 <p>
                   Only [=dictionary member/present=] for video. Represents the bit depth per pixel of the last encoded frame.
                   Typical values are 24, 30, or 36 bits.
-                  Before the first frame is encoded this attribute is missing.
+                  Before the first frame is encoded this member is [=dictionary member/not present=].
                 </p>
               </dd>
               <dt>
@@ -2812,7 +2812,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The width, in pixels, of the last frame originating from this source. Before a
-                  frame has been produced this attribute is missing.
+                  frame has been produced this member is [=dictionary member/not present=].
                 </p>
               </dd>
               <dt>
@@ -2822,7 +2822,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The height, in pixels, of the last frame originating from this source. Before a
-                  frame has been produced this attribute is missing.
+                  frame has been produced this member is [=dictionary member/not present=].
                 </p>
               </dd>
               <dt>
@@ -2832,7 +2832,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The bit depth per pixel of the last frame originating from this source. Before a
-                  frame has been produced this attribute is missing.
+                  frame has been produced this member is [=dictionary member/not present=].
                 </p>
               </dd>
 
@@ -2851,7 +2851,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The number of frames originating from this source, measured during the last
-                  second. For the first second of this object's lifetime this attribute is missing.
+                  second. For the first second of this object's lifetime this member is [=dictionary member/not present=].
                 </p>
               </dd>
             </dl>
@@ -4403,7 +4403,7 @@ enum RTCStatsType {
         <p>
           If a video track is attached twice (via addTransceiver or replaceTrack), there will be
           two RTCSenderVideoTrackAttachmentStats objects, one for each attachment. They will have
-          the same "trackIdentifier" attribute, but different "id" attributes.
+          the same "trackIdentifier" member, but different "id" members.
         </p>
         <p>
           This dictionary was made obsolete after its members were moved to "media-source",
@@ -4430,7 +4430,7 @@ enum RTCStatsType {
         <p>
           If an audio track is attached twice (via addTransceiver or replaceTrack), there will be
           two RTCSenderAudioTrackAttachmentStats objects, one for each attachment. They will have
-          the same "trackIdentifier" attribute, but different "id" attributes.
+          the same "trackIdentifier" member, but different "id" members.
         </p>
         <p>
           This dictionary was made obsolete after its members were moved to "media-source",

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1114,7 +1114,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The total number of frames dropped prior to decode or dropped
+                  Only [=dictionary member/present=] for video. The total number of frames dropped prior to decode or dropped
                   because the frame missed its display deadline for this receiver's track. The measurement
                   begins when the receiver is created and is a cumulative metric as defined in 
                   Appendix A (g) of [[!RFC7004]].
@@ -1126,7 +1126,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The cumulative number of partial frames lost. The measurement
+                  Only [=dictionary member/present=] for video. The cumulative number of partial frames lost. The measurement
                   begins when the receiver is created and is a cumulative metric as defined in
                   Appendix A (j) of [[!RFC7004]]. This metric is incremented when the frame is sent
                   to the decoder. If the partial frame is received and recovered via retransmission
@@ -1139,7 +1139,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The cumulative number of full frames lost. The measurement
+                  Only [=dictionary member/present=] for video. The cumulative number of full frames lost. The measurement
                   begins when the receiver is created and is a cumulative metric as defined in
                   Appendix A (i) of [[!RFC7004]].
                 </p>
@@ -1243,7 +1243,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It represents the total number of frames correctly decoded
+                  Only [=dictionary member/present=] for video. It represents the total number of frames correctly decoded
                   for this <a>RTP stream</a>, i.e., frames that would be displayed if no frames are dropped.
                 </p>
               </dd>
@@ -1253,7 +1253,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It represents the total number of key frames, such as key
+                  Only [=dictionary member/present=] for video. It represents the total number of key frames, such as key
                   frames in VP8 [[RFC6386]] or IDR-frames in H.264 [[RFC6184]], successfully
                   decoded for this RTP media stream. This is a subset of
                   {{framesDecoded}}. <code>framesDecoded - keyFramesDecoded</code> gives
@@ -1266,7 +1266,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the width of the last decoded frame. Before the
+                  Only [=dictionary member/present=] for video. Represents the width of the last decoded frame. Before the
                   first frame is decoded this attribute is missing.
                 </p>
               </dd>
@@ -1276,7 +1276,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the height of the last decoded frame. Before
+                  Only [=dictionary member/present=] for video. Represents the height of the last decoded frame. Before
                   the first frame is decoded this attribute is missing.
                 </p>
               </dd>
@@ -1286,7 +1286,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the bit depth per pixel of the last decoded frame.
+                  Only [=dictionary member/present=] for video. Represents the bit depth per pixel of the last decoded frame.
                   Typical values are 24, 30, or 36 bits.
                   Before the first frame is decoded this attribute is missing.
                 </p>
@@ -1297,7 +1297,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The number of decoded frames in the last second.
+                  Only [=dictionary member/present=] for video. The number of decoded frames in the last second.
                 </p>
               </dd>
               <dt>
@@ -1306,8 +1306,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The sum of the QP values of frames decoded by this
+                  Only [=dictionary member/present=] for video. The sum of the QP values of frames decoded by this
                   receiver. The count of frames is in {{framesDecoded}}.
+
                 </p>
                 <p>
                   The definition of QP value depends on the codec; for VP8, the QP value is the
@@ -1364,8 +1365,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. Whether the last RTP packet whose frame was delivered to the
+                  Only [=dictionary member/present=] for audio. Whether the last RTP packet whose frame was delivered to the
                   {{RTCRtpReceiver}}'s {{MediaStreamTrack}} for playout contained voice activity or not based
+
                   on the presence of the V bit in the extension header, as defined in [[RFC6464]]. This
                   is the stats-equivalent of {{RTCRtpSynchronizationSource}}.{{RTCRtpSynchronizationSource/voiceActivityFlag}}
                   in [[WEBRTC].
@@ -1485,7 +1487,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Count the total number of Full Intra Request (FIR) packets
+                  Only [=dictionary member/present=] for video. Count the total number of Full Intra Request (FIR) packets
                   sent by this receiver. Calculated as defined in [[!RFC5104]] section 4.3.1. and
                   does not use the metric indicated in [[RFC2032]], because it was deprecated by
                   [[RFC4587]].
@@ -1497,7 +1499,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Count the total number of Picture Loss Indication (PLI)
+                  Only [=dictionary member/present=] for video. Count the total number of Picture Loss Indication (PLI)
                   packets sent by this receiver. Calculated as defined in [[!RFC4585]] section
                   6.3.1.
                 </p>
@@ -1518,7 +1520,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Count the total number of Slice Loss Indication (SLI)
+                  Only [=dictionary member/present=] for video. Count the total number of Slice Loss Indication (SLI)
                   packets sent by this receiver. Calculated as defined in [[!RFC4585]] section
                   6.3.2.
                 </p>
@@ -1574,8 +1576,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. The total number of samples that have been received on this
-                  <a>RTP stream</a>. This includes {{concealedSamples}}.
+                  Only [=dictionary member/present=] for audio. The total number of samples that have been received on this
+                  RTP stream. This includes {{concealedSamples}}.
                 </p>
                 
               </dd>
@@ -1585,7 +1587,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio and when the audio codec is Opus. The total number of 
+                  Only [=dictionary member/present=] for audio and when the audio codec is Opus. The total number of 
                   samples decoded by the SILK portion of the Opus codec.
                 </p>
               </dd>
@@ -1595,7 +1597,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio and when the audio codec is Opus. The total number of 
+                  Only [=dictionary member/present=] for audio and when the audio codec is Opus. The total number of 
                   samples decoded by the CELT portion of the Opus codec.
                 </p>
               </dd>
@@ -1605,7 +1607,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. The total number of samples that are concealed samples. A
+                  Only [=dictionary member/present=] for audio. The total number of samples that are concealed samples. A
                   concealed sample is a sample that was replaced with synthesized samples generated
                   locally before being played out. Examples of samples that have to be concealed
                   are samples from lost packets (reported in {{RTCReceivedRtpStreamStats/packetsLost}}) or samples from packets that arrive
@@ -1619,7 +1621,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. The total number of concealed samples inserted that are
+                  Only [=dictionary member/present=] for audio. The total number of concealed samples inserted that are
                   "silent". Playing out silent samples results in silence or comfort noise. This is
                   a subset of {{concealedSamples}}.
                 </p>
@@ -1631,7 +1633,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. The number of concealment events. This counter increases every
+                  Only [=dictionary member/present=] for audio. The number of concealment events. This counter increases every
                   time a concealed sample is synthesized after a non-concealed sample. That is, multiple
                   consecutive concealed samples will increase the {{concealedSamples}} count multiple
                   times but is a single concealment event.
@@ -1644,7 +1646,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. When playout is slowed down, this counter is increased by the
+                  Only [=dictionary member/present=] for audio. When playout is slowed down, this counter is increased by the
                   difference between the number of samples received and the number of samples played out.
                   If playout is slowed down by inserting samples, this will be the number of inserted
                   samples.
@@ -1657,7 +1659,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. When playout is sped up, this counter is increased by the
+                  Only [=dictionary member/present=] for audio. When playout is sped up, this counter is increased by the
                   difference between the number of samples received and the number of samples played
                   out. If speedup is achieved by removing samples, this will be the count of samples
                   removed.
@@ -1670,7 +1672,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. Represents the audio level of the receiving track. For audio
+                  Only [=dictionary member/present=] for audio. Represents the audio level of the receiving track. For audio
                   levels of tracks attached locally, see {{RTCAudioSourceStats}}
                   instead.
                 </p>
@@ -1691,7 +1693,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. Represents the audio energy of the receiving track. For
+                  Only [=dictionary member/present=] for audio. Represents the audio energy of the receiving track. For
                   audio energy of tracks attached locally, see
                   {{RTCAudioSourceStats}} instead.
                 </p>
@@ -1734,7 +1736,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. Represents the audio duration of the receiving track. For
+                  Only [=dictionary member/present=] for audio. Represents the audio duration of the receiving track. For
                   audio durations of tracks attached locally, see
                   {{RTCAudioSourceStats}} instead.
                 </p>
@@ -1752,7 +1754,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the total number of complete frames received on
+                  Only [=dictionary member/present=] for video. Represents the total number of complete frames received on
                   this <a>RTP stream</a>. This metric is incremented when the complete frame is received.
                 </p>
               </dd>
@@ -2122,8 +2124,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the width of the last encoded frame. The resolution
-                  of the encoded frame may be lower than the media source (see {{RTCVideoSourceStats}}.{{RTCVideoSourceStats/width}}).
+                  Only [=dictionary member/present=] for video. Represents the width of the last encoded frame. The resolution
+                  of the encoded frame may be lower than the media source (see {{RTCVideoSourceStats.width}}).
                   Before the first frame is encoded this attribute is missing.
                 </p>
               </dd>
@@ -2133,8 +2135,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the height of the last encoded frame. The resolution
-                  of the encoded frame may be lower than the media source (see {{RTCVideoSourceStats}}.{{RTCVideoSourceStats/height}}).
+                  Only [=dictionary member/present=] for video. Represents the height of the last encoded frame. The resolution
+                  of the encoded frame may be lower than the media source (see {{RTCVideoSourceStats.height}}).
                   Before the first frame is encoded this attribute is missing.
                 </p>
               </dd>
@@ -2144,7 +2146,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the bit depth per pixel of the last encoded frame.
+                  Only [=dictionary member/present=] for video. Represents the bit depth per pixel of the last encoded frame.
                   Typical values are 24, 30, or 36 bits.
                   Before the first frame is encoded this attribute is missing.
                 </p>
@@ -2155,8 +2157,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The number of encoded frames during the last second. This may be
-                  lower than the media source frame rate (see {{RTCVideoSourceStats}}.{{RTCVideoSourceStats/framesPerSecond}}).
+                  Only [=dictionary member/present=] for video. The number of encoded frames during the last second. This may be
+                  lower than the media source frame rate (see {{RTCVideoSourceStats.framesPerSecond}}).
                 </p>
               </dd>
               <dt>
@@ -2165,7 +2167,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the total number of frames sent on this <a>RTP stream</a>.
+                  Only [=dictionary member/present=] for video. Represents the total number of frames sent on this <a>RTP stream</a>.
                 </p>
               </dd>
               <dt>
@@ -2174,7 +2176,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Represents the total number of huge frames sent by this RTP
+                  Only [=dictionary member/present=] for video. Represents the total number of huge frames sent by this RTP
                   stream. Huge frames, by definition, are frames that have an encoded size at least
                   2.5 times the average size of the frames. The average size of the frames is defined
                   as the target bitrate per second divided by the target FPS at the time the frame was
@@ -2195,7 +2197,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It represents the total number of frames successfully
+                  Only [=dictionary member/present=] for video. It represents the total number of frames successfully
                   encoded for this RTP media stream.
                 </p>
               </dd>
@@ -2205,7 +2207,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. It represents the total number of key frames, such as key
+                  Only [=dictionary member/present=] for video. It represents the total number of key frames, such as key
                   frames in VP8 [[RFC6386]] or IDR-frames in H.264 [[RFC6184]], successfully
                   encoded for this RTP media stream. This is a subset of
                   {{framesEncoded}}. <code>framesEncoded - keyFramesEncoded</code> gives
@@ -2230,7 +2232,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The sum of the QP values of frames encoded by this sender.
+                  Only [=dictionary member/present=] for video. The sum of the QP values of frames encoded by this sender.
                   The count of frames is in {{framesEncoded}}.
                 </p>
                 <p>
@@ -2250,7 +2252,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. The total number of samples that have been sent over this
+                  Only [=dictionary member/present=] for audio. The total number of samples that have been sent over this
                   <a>RTP stream</a>.
                 </p>
                 
@@ -2261,7 +2263,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio and when the audio codec is Opus. The total number of 
+                  Only [=dictionary member/present=] for audio and when the audio codec is Opus. The total number of 
                   samples encoded by the SILK portion of the Opus codec.
                 </p>
               </dd>
@@ -2271,7 +2273,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio and when the audio codec is Opus. The total number of 
+                  Only [=dictionary member/present=] for audio and when the audio codec is Opus. The total number of 
                   samples encoded by the CELT portion of the Opus codec.
                 </p>
               </dd>
@@ -2281,7 +2283,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for audio. Whether the last RTP packet sent contained voice activity
+                  Only [=dictionary member/present=] for audio. Whether the last RTP packet sent contained voice activity
                   or not based on the presence of the V bit in the extension header, as defined in
                   [[RFC6464]].
                 </p>
@@ -2331,7 +2333,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The current reason for limiting the resolution and/or
+                  Only [=dictionary member/present=] for video. The current reason for limiting the resolution and/or
                   framerate, or {{RTCQualityLimitationReason/"none"}} if not limited.
                 </p>
                 <p>
@@ -2356,7 +2358,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. A record of the total time, in seconds, that this stream
+                  Only [=dictionary member/present=] for video. A record of the total time, in seconds, that this stream
                   has spent in each quality limitation state. The record includes a mapping for all
                   {{RTCQualityLimitationReason}} types, including {{RTCQualityLimitationReason/"none"}}.
                 </p>
@@ -2371,7 +2373,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. The number of times that the resolution has changed because
+                  Only [=dictionary member/present=] for video. The number of times that the resolution has changed because
                   we are quality limited ({{qualityLimitationReason}} has a value other than
                   {{RTCQualityLimitationReason/"none"}}). The counter is initially zero and increases when the
                   resolution goes up or down. For example, if a 720p track is sent as 480p for some
@@ -2405,7 +2407,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Count the total number of Full Intra Request (FIR) packets
+                  Only [=dictionary member/present=] for video. Count the total number of Full Intra Request (FIR) packets
                   received by this sender. Calculated as defined in [[!RFC5104]] section 4.3.1. and
                   does not use the metric indicated in [[RFC2032]], because it was deprecated by
                   [[RFC4587]].
@@ -2417,7 +2419,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Count the total number of Picture Loss Indication (PLI)
+                  Only [=dictionary member/present=] for video. Count the total number of Picture Loss Indication (PLI)
                   packets received by this sender. Calculated as defined in [[!RFC4585]] section
                   6.3.1.
                 </p>
@@ -2428,7 +2430,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only valid for video. Count the total number of Slice Loss Indication (SLI)
+                  Only [=dictionary member/present=] for video. Count the total number of Slice Loss Indication (SLI)
                   packets received by this sender. Calculated as defined in [[!RFC4585]] section
                   6.3.2.
                 </p>
@@ -2752,7 +2754,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only present when the {{MediaStreamTrack}} is sourced from a microphone where
+                  Only [=dictionary member/present=] when the {{MediaStreamTrack}} is sourced from a microphone where
                   echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
                   (2012) section 3.14.
                 </p>
@@ -2767,7 +2769,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only present when the {{MediaStreamTrack}} is sourced from a microphone where
+                  Only [=dictionary member/present=] when the {{MediaStreamTrack}} is sourced from a microphone where
                   echo cancellation is applied. Calculated in decibels, as defined in [[!ECHO]]
                   (2012) section 3.15.
                 </p>
@@ -3543,7 +3545,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  For components where DTLS is negotiated, the TLS version agreed. Only present
+                  For components where DTLS is negotiated, the TLS version agreed. Only [=dictionary member/present=]
                   after DTLS negotiation is complete.
                 </p>
                 <p>


### PR DESCRIPTION
…f stream

Presumably the intent is that if the stream is not of the right kind, the data should not be included ('valid' makes it seem like it would be ok to send garbage data in other cases)