### PR TITLE
Make concept definitions normative

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -97,7 +97,7 @@
       <p>The term <dfn data-lt="Extended Report|XR"><a href="https://tools.ietf.org/html/rfc3611">RTCP Extended Report</a></dfn> is defined in [[RFC3611]].</p>
       <p>An <dfn>audio sample</dfn> refers to having a sample in any channel of an audio track - if multiple audio channels are used, metrics based on samples do not increment at a higher rate, simultaneously having samples in multiple channels counts as a single sample.</p>
     </section>
-    <section class="informative">
+    <section>
       <h2>
         Basic concepts
       </h2>
@@ -154,7 +154,7 @@
         {{RTCStats}} dictionary. This API is normatively defined in [[!WEBRTC]], but is
         reproduced here for ease of reference.
       </p>
-      <pre class="idl">
+      <pre class="idl informative">
 dictionary RTCStats {
     required DOMHighResTimeStamp timestamp;
     required RTCStatsType        type;


### PR DESCRIPTION
Only the imported IDL fragment is meant to be information-only