### PR TITLE
Correct packetsReceived sender-side algorithm to rely on RR.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -987,7 +987,7 @@ enum RTCStatsType {
                   Total number of RTP packets received for this <a>SSRC</a>. At the receiving endpoint,
                   this is calculated as defined in [[!RFC3550]] section 6.4.1. At the sending
                   endpoint the {{packetsReceived}} can be estimated by subtracting the Cumulative Number
-                  of Packets Lost from the expected Highest Sequence Number Received, both reported in the
+                  of Packets Lost from the expected Extended Highest Sequence Number Received, both reported in the
                   <a>RTCP Receiver Report</a> as discussed in Appendix A.3. in [[!RFC3550]].
                 </p>
               </dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -986,9 +986,9 @@ enum RTCStatsType {
                 <p>
                   Total number of RTP packets received for this <a>SSRC</a>. At the receiving endpoint,
                   this is calculated as defined in [[!RFC3550]] section 6.4.1. At the sending
-                  endpoint the {{packetsReceived}} can be calculated by subtracting the packets lost
-                  from the expected Highest Sequence Number reported in the <a>RTCP Sender Report</a> as
-                  discussed in Appendix A.3. in [[!RFC3550]].
+                  endpoint the {{packetsReceived}} can be calculated by subtracting the Cumulative Number
+                  of Packets Lost from the expected Highest Sequence Number Received, both reported in the
+                  <a>RTCP Receiver Report</a> as discussed in Appendix A.3. in [[!RFC3550]].
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -986,7 +986,7 @@ enum RTCStatsType {
                 <p>
                   Total number of RTP packets received for this <a>SSRC</a>. At the receiving endpoint,
                   this is calculated as defined in [[!RFC3550]] section 6.4.1. At the sending
-                  endpoint the {{packetsReceived}} can be calculated by subtracting the Cumulative Number
+                  endpoint the {{packetsReceived}} can be estimated by subtracting the Cumulative Number
                   of Packets Lost from the expected Highest Sequence Number Received, both reported in the
                   <a>RTCP Receiver Report</a> as discussed in Appendix A.3. in [[!RFC3550]].
                 </p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -986,9 +986,11 @@ enum RTCStatsType {
                 <p>
                   Total number of RTP packets received for this <a>SSRC</a>. At the receiving endpoint,
                   this is calculated as defined in [[!RFC3550]] section 6.4.1. At the sending
-                  endpoint the {{packetsReceived}} can be estimated by subtracting the Cumulative Number
-                  of Packets Lost from the expected Extended Highest Sequence Number Received, both reported in the
-                  <a>RTCP Receiver Report</a> as discussed in Appendix A.3. in [[!RFC3550]].
+                  endpoint the {{packetsReceived}} is estimated by subtracting the Cumulative Number of Packets Lost
+                  from the Extended Highest Sequence Number Received, both reported in the <a>RTCP Receiver
+                  Report</a>, and then subtracting the initial Extended Sequence Number that was sent to this SSRC in a
+                  <a>RTCP Sender Report</a>, to mirror what is discussed in Appendix A.3 in [[!RFC3550]], but for the
+                  sender side.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -989,8 +989,8 @@ enum RTCStatsType {
                   endpoint the {{packetsReceived}} is estimated by subtracting the Cumulative Number of Packets Lost
                   from the Extended Highest Sequence Number Received, both reported in the <a>RTCP Receiver
                   Report</a>, and then subtracting the initial Extended Sequence Number that was sent to this SSRC in a
-                  <a>RTCP Sender Report</a>, to mirror what is discussed in Appendix A.3 in [[!RFC3550]], but for the
-                  sender side.
+                  <a>RTCP Sender Report</a> and then adding one, to mirror what is discussed in Appendix A.3 in [[!RFC3550]], but for the
+                  sender side. If no <a>RTCP Receiver Report</a> has been received yet, then return 0.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -52,7 +52,7 @@ var respecConfig = {
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-webrtc",
 
-  xref: ["html", "webrtc", "mediacapture-streams", "webidl", "dom", "hr-time", "infra"],
+  xref: ["html", "webrtc", "mediacapture-streams", "webidl", "dom", "hr-time", "infra", "webrtc-extensions"],
       github: "https://github.com/w3c/webrtc-stats",
   testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/webrtc-stats",
     implementationReportURI: "https://wpt.fyi/webrtc-stats",


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-stats/issues/592


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-stats/pull/591.html" title="Last updated on Jan 20, 2021, 12:39 PM UTC (194a2f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/591/9c46e59...jan-ivar:194a2f7.html" title="Last updated on Jan 20, 2021, 12:39 PM UTC (194a2f7)">Diff</a>