### PR TITLE
Wrong type for video_source_stats.frames

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2916,7 +2916,7 @@ enum RTCStatsType {
               </dd>
 
               <dt>
-                <dfn>frames</dfn> of type <span class="idlMemberType">frames</span>
+                <dfn>frames</dfn> of type <span class="idlMemberType">unsigned long</span>
               </dt>
               <dd>
                 <p>


### PR DESCRIPTION
Should be `unsigned long` rather than `frames`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 5, 2021, 2:55 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Ftjwudi%2Fwebrtc-stats%2F3fde48fbf509b8770edb52052cb87fd75518ce4a%2Fwebrtc-stats.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 429: https://rawcdn.githack.com/tjwudi/webrtc-stats/3fde48fbf509b8770edb52052cb87fd75518ce4a/webrtc-stats.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-stats%23598.)._
</details>
