### PR TITLE
Update links to IETF to use datatracker rather than tools.ietf.org

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -91,10 +91,10 @@
       </p>
       <p><dfn class=fixme data-idl>RTCPriorityType</dfn> is defined in [[WEBRTC-PRIORITY]].</p>
       <p>
-        The term <dfn><a href="https://tools.ietf.org/html/rfc7656#section-2.1.10">RTP stream</a></dfn> is defined in [[RFC7656]].
+        The term <dfn><a href="https://datatracker.ietf.org/doc/html/rfc7656#section-2.1.10">RTP stream</a></dfn> is defined in [[RFC7656]].
       </p>
-      <p>The terms <dfn data-lt="SSRC"><a href="https://tools.ietf.org/html/rfc3550#section-3">Synchronization Source</a></dfn> (SSRC), <dfn data-lt="Sender Report|SR|RTCP SR"><a href="https://tools.ietf.org/html/rfc3550#section-6.4.1">RTCP Sender Report</a></dfn>, <dfn data-lt="Receiver Report|RR|RTCP RR"><a href="https://tools.ietf.org/html/rfc3550#section-6.4.2">RTCP Receiver Report</a></dfn> are defined in [[RFC3550]].</p>
-      <p>The term <dfn data-lt="Extended Report|XR"><a href="https://tools.ietf.org/html/rfc3611">RTCP Extended Report</a></dfn> is defined in [[RFC3611]].</p>
+      <p>The terms <dfn data-lt="SSRC"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-3">Synchronization Source</a></dfn> (SSRC), <dfn data-lt="Sender Report|SR|RTCP SR"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1">RTCP Sender Report</a></dfn>, <dfn data-lt="Receiver Report|RR|RTCP RR"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.2">RTCP Receiver Report</a></dfn> are defined in [[RFC3550]].</p>
+      <p>The term <dfn data-lt="Extended Report|XR"><a href="https://datatracker.ietf.org/doc/html/rfc3611">RTCP Extended Report</a></dfn> is defined in [[RFC3611]].</p>
       <p>An <dfn>audio sample</dfn> refers to having a sample in any channel of an audio track - if multiple audio channels are used, metrics based on samples do not increment at a higher rate, simultaneously having samples in multiple channels counts as a single sample.</p>
     </section>
     <section>

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -70,7 +70,7 @@ var respecConfig = {
       localBiblio:  {
         "XRBLOCK-STATS": {
             title:    "RTCP XR Metrics for WebRTC",
-            href:     "https://tools.ietf.org/html/draft-ietf-xrblock-rtcweb-rtcp-xr-metrics",
+            href:     "https://datatracker.ietf.org/doc/html/draft-ietf-xrblock-rtcweb-rtcp-xr-metrics",
             authors:  [
                 "Varun Singh",
                 "Rachel Huang",
@@ -90,7 +90,7 @@ var respecConfig = {
         },
         "STUN-PATH-CHAR": {
           title:    "Discovery of path characteristics using STUN",
-            href:     "https://tools.ietf.org/html/draft-reddy-tram-stun-path-data",
+            href:     "https://datatracker.ietf.org/doc/html/draft-reddy-tram-stun-path-data",
             authors:  [
                 "T. Reddy",
                 "D. Wing",


### PR DESCRIPTION
per https://mailarchive.ietf.org/arch/msg/tools-discuss/oYrAxb3KayPzZ4SNB1DVZTDPPNo/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/pull/599.html" title="Last updated on Mar 16, 2021, 8:56 AM UTC (d01500f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/599/9405d5b...d01500f.html" title="Last updated on Mar 16, 2021, 8:56 AM UTC (d01500f)">Diff</a>