### PR TITLE
Add RTT stats to RemoteOutboundRtpStreamStats

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2655,8 +2655,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Estimated round trip time for this <a>SSRC</a> based on an <a>RTCP Sender Report</a> (SR)
-                  that contains an <a>DLRR</a> report block as defined in [[!RFC3611]]. The Calculation of
+                  Estimated round trip time for this <a>SSRC</a> based on the latest <a>RTCP Sender Report</a> (SR)
+                  that contains a <a>DLRR</a> report block as defined in [[!RFC3611]]. The Calculation of
                   the round trip time is defined in section 4.5. of [[!RFC3611]]. If no SR contains the DLRR
                   report block, or if the <a>delay since last RR</a> value in DLRR report blocks are all 0s,
                   the round trip time is left undefined.

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2656,10 +2656,10 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Estimated round trip time for this <a>SSRC</a> based on the latest <a>RTCP Sender Report</a> (SR)
-                  that contains a <a>DLRR</a> report block as defined in [[!RFC3611]]. The Calculation of
+                  that contains a DLRR report block as defined in [[!RFC3611]]. The Calculation of
                   the round trip time is defined in section 4.5. of [[!RFC3611]]. If the latest SR does not contain
                   the DLRR report block, or if the last RR timestamp in the DLRR report block is zero, or if the
-                  <a>delay since last RR</a> value in the DLRR report block is zero, the round trip time is left
+                  delay since last RR value in the DLRR report block is zero, the round trip time is left
                   undefined.
                 </p>
               </dd>
@@ -2671,7 +2671,7 @@ enum RTCStatsType {
                 <p>
                   Represents the cumulative sum of all round trip time measurements in seconds since the
                   beginning of the session. The individual round trip time is calculated  based on the
-                  <a>DLRR</a> report block in the <a>RTCP Sender Report</a> (SR) [[!RFC3611]], hence
+                  DLRR report block in the <a>RTCP Sender Report</a> (SR) [[!RFC3611]], hence
                   undefined roundtrip times are not added. The average round trip time can be computed 
                   from {{totalRoundTripTime}} by dividing it by {{roundTripTimeMeasurements}}.
                 </p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2657,9 +2657,10 @@ enum RTCStatsType {
                 <p>
                   Estimated round trip time for this <a>SSRC</a> based on the latest <a>RTCP Sender Report</a> (SR)
                   that contains a <a>DLRR</a> report block as defined in [[!RFC3611]]. The Calculation of
-                  the round trip time is defined in section 4.5. of [[!RFC3611]]. If the latest SR does not contain the DLRR
-                  report block, or if the last RR timestamp in the DLRR report block is zero, or if the <a>delay since last RR</a> value in the DLRR report block is zero,
-                  the round trip time is left undefined.
+                  the round trip time is defined in section 4.5. of [[!RFC3611]]. If the latest SR does not contain
+                  the DLRR report block, or if the last RR timestamp in the DLRR report block is zero, or if the
+                  <a>delay since last RR</a> value in the DLRR report block is zero, the round trip time is left
+                  undefined.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2605,6 +2605,9 @@ enum RTCStatsType {
              DOMString           localId;
              DOMHighResTimeStamp remoteTimestamp;
              unsigned long long  reportsSent;
+             double              roundTripTime;
+             double              totalRoundTripTime;
+             unsigned long long  roundTripTimeMeasurements;
 };</pre>
           <section>
             <h2>
@@ -2644,6 +2647,43 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the total number of <a>RTCP SR</a> blocks sent for this <a>SSRC</a>.
+                </p>
+              </dd>
+              <dt>
+                <dfn>roundTripTime</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  Estimated round trip time for this <a>SSRC</a> based on an <a>RTCP Sender Report</a> (SR)
+                  that contains an <a>DLRR</a> report block as defined in [[!RFC3611]]. The Calculation of
+                  the round trip time is defined in section 4.5. of [[!RFC3611]]. If no SR contains the DLRR
+                  report block, or if the <a>delay since last RR</a> value in DLRR report blocks are all 0s,
+                  the round trip time is left undefined.
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalRoundTripTime</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the cumulative sum of all round trip time measurements in seconds since the
+                  beginning of the session. The individual round trip time is calculated  based on the
+                  <a>DLRR</a> report block in the <a>RTCP Sender Report</a> (SR) [[!RFC3611]], hence
+                  undefined roundtrip times are not added. The average round trip time can be computed 
+                  from {{totalRoundTripTime}} by dividing it by {{roundTripTimeMeasurements}}.
+                </p>
+              </dd>
+              <dt>
+                <dfn>roundTripTimeMeasurements</dfn> of type <span class=
+                "idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  Represents the total number of <a>RTCP Sender Report</a> (SR) blocks received for this
+                  <a>SSRC</a> that can derive a valid round trip time according to [[!RTC3611]]. This
+                  counter will not increment if the {{roundTripTime}} is undefined.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2658,7 +2658,7 @@ enum RTCStatsType {
                   Estimated round trip time for this <a>SSRC</a> based on the latest <a>RTCP Sender Report</a> (SR)
                   that contains a <a>DLRR</a> report block as defined in [[!RFC3611]]. The Calculation of
                   the round trip time is defined in section 4.5. of [[!RFC3611]]. If the latest SR does not contain the DLRR
-                  report block, or if the <a>delay since last RR</a> value in DLRR report blocks are all 0s,
+                  report block, or if the last RR timestamp in the DLRR report block is zero, or if the <a>delay since last RR</a> value in the DLRR report block is zero,
                   the round trip time is left undefined.
                 </p>
               </dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2682,7 +2682,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the total number of <a>RTCP Sender Report</a> (SR) blocks received for this
-                  <a>SSRC</a> that can derive a valid round trip time according to [[!RTC3611]]. This
+                  <a>SSRC</a> that can derive a valid round trip time according to [[!RFC3611]]. This
                   counter will not increment if the {{roundTripTime}} is undefined.
                 </p>
               </dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2657,7 +2657,7 @@ enum RTCStatsType {
                 <p>
                   Estimated round trip time for this <a>SSRC</a> based on the latest <a>RTCP Sender Report</a> (SR)
                   that contains a <a>DLRR</a> report block as defined in [[!RFC3611]]. The Calculation of
-                  the round trip time is defined in section 4.5. of [[!RFC3611]]. If no SR contains the DLRR
+                  the round trip time is defined in section 4.5. of [[!RFC3611]]. If the latest SR does not contain the DLRR
                   report block, or if the <a>delay since last RR</a> value in DLRR report blocks are all 0s,
                   the round trip time is left undefined.
                 </p>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/minyuel/webrtc-stats/pull/603.html" title="Last updated on Apr 27, 2021, 8:15 PM UTC (b43c9cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/603/0ba4e81...minyuel:b43c9cd.html" title="Last updated on Apr 27, 2021, 8:15 PM UTC (b43c9cd)">Diff</a>