### PR TITLE
Fix import of WebIDL2 library

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -11,7 +11,7 @@
     <script class="remove" src="webrtc-stats.js">
     </script>
     <!-- TODO Redundant since webidl2.js is already loaded in ReSpec, but not sure how to access it -->
-    <script src="https://w3c.github.io/webidl2.js/dist/webidl2.js"></script>
+    <script class="remove" src="https://unpkg.com/webidl2@24/dist/webidl2.js"></script>
   </head>
   <body>
     <section id="abstract">


### PR DESCRIPTION
Needed for stats summary table. Close #606


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/pull/607.html" title="Last updated on Jun 23, 2021, 8:54 AM UTC (a39753b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/607/7bc292b...a39753b.html" title="Last updated on Jun 23, 2021, 8:54 AM UTC (a39753b)">Diff</a>