### PR TITLE
add missing fields to candidate stats

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -664,7 +664,7 @@ enum RTCStatsType {
           <code>"inactive"</code> or if the encoding's
           {{RTCRtpEncodingParameters/active}} parameter is set to
           <code>false</code>. If an SSRC is recycled after a deletion event has
-          happened, this is considered a new RTP monitored object and the new 
+          happened, this is considered a new RTP monitored object and the new
           RTP stream stats will have reset counters and a new ID.
         </p>
         <p>
@@ -3166,6 +3166,7 @@ enum RTCStatsType {
              long                     priority;
              DOMString                url;
              RTCIceServerTransportProtocol relayProtocol;
+             DOMString                tcpType;
 };</pre>
           <section>
             <h2>
@@ -3261,6 +3262,14 @@ enum RTCStatsType {
                 <p>
                   It is the protocol used by the endpoint to communicate with the TURN server. This
                   is only present for local relay candidates and defined in [[WEBRTC]].
+                </p>
+              </dd>
+              <dt>
+                <dfn>tcpType</dfn> of type <span class="idlMemberType">DOMString</span>
+              </dt>
+              <dd>
+                <p>
+                  As defined in [[WEBRTC]].
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3269,7 +3269,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  As defined in [[WEBRTC]].
+                  ICE candidate TCP type, as defined іn {{RTCIceTcpCandidateType}} and used
+                  in {{RTCIceCandidate}}.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3166,7 +3166,11 @@ enum RTCStatsType {
              long                     priority;
              DOMString                url;
              RTCIceServerTransportProtocol relayProtocol;
-             DOMString                tcpType;
+             DOMString                foundation;
+             DOMString                relatedAddress;
+             long                     relatedPort;
+             DOMString                usernameFragment;
+             RTCIceTcpCandidateType   tcpType;
 };</pre>
           <section>
             <h2>
@@ -3265,11 +3269,46 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn>tcpType</dfn> of type <span class="idlMemberType">DOMString</span>
+                <dfn>foundation</dfn> of type <span class="idlMemberType">DOMString</span>
               </dt>
               <dd>
                 <p>
-                  ICE candidate TCP type, as defined іn {{RTCIceTcpCandidateType}} and used
+                  The ICE foundation as defined in [[!RFC5245]] section 15.1.
+                </p>
+              </dd>
+              <dt>
+                <dfn>relatedAddress</dfn> of type <span class="idlMemberType">DOMString</span>
+              </dt>
+              <dd>
+                <p>
+                  The ICE rel-addr defined in [[!RFC5245]] section 15.1. Only set for serverreflexive
+                  and relay candidates.
+                </p>
+              </dd>
+              <dt>
+                <dfn>relatedPort</dfn> of type <span class="idlMemberType">long</span>
+              </dt>
+              <dd>
+                <p>
+                  The ICE rel-addr defined in [[!RFC5245]] section 15.1. Only set for serverreflexive
+                  and relay candidates.
+                </p>
+              </dd>
+              <dt>
+                <dfn>usernameFragment</dfn> of type <span class="idlMemberType">DOMString</span>
+              </dt>
+              <dd>
+                <p>
+                  The ICE username fragment as defined in [[!RFC5245]] section 7.1.2.3.
+                </p>
+              </dd>
+              <dt>
+              <dt>
+                <dfn>tcpType</dfn> of type <span class="idlMemberType">{{RTCIceTcpCandidateType}}</span>
+              </dt>
+              <dd>
+                <p>
+                  The ICE candidate TCP type, as defined іn {{RTCIceTcpCandidateType}} and used
                   in {{RTCIceCandidate}}.
                 </p>
               </dd>


### PR DESCRIPTION
* foundation
* relatedAddress
* relatedPort
* usernameFragment
* tcpType
all of which are already defined for the ICE candidate object itself

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/611.html" title="Last updated on Nov 8, 2021, 8:46 AM UTC (9a90be0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/611/cb32f08...fippo:9a90be0.html" title="Last updated on Nov 8, 2021, 8:46 AM UTC (9a90be0)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/611.html" title="Last updated on Oct 4, 2022, 12:20 PM UTC (65f6bc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/611/ad722e9...fippo:65f6bc6.html" title="Last updated on Oct 4, 2022, 12:20 PM UTC (65f6bc6)">Diff</a>