### PR TITLE
Match channels stat language with that of channels parameter.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -889,7 +889,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Use 2 for stereo, missing for most other cases.
+                  When present, indicates the number of channels (mono=1, stereo=2).
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-stats/issues/615.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-stats/pull/618.html" title="Last updated on Jan 21, 2022, 6:35 PM UTC (67dbc3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/618/0a0a1d2...jan-ivar:67dbc3d.html" title="Last updated on Jan 21, 2022, 6:35 PM UTC (67dbc3d)">Diff</a>