### PR TITLE
Remove outbound-rtp.rid

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1990,7 +1990,6 @@ enum RTCStatsType {
              DOMString            mediaSourceId;
              DOMString            senderId;
              DOMString            remoteId;
-             DOMString            rid;
              DOMHighResTimeStamp  lastPacketSentTimestamp;
              unsigned long long   headerBytesSent;
              unsigned long        packetsDiscardedOnSend;
@@ -2072,17 +2071,6 @@ enum RTCStatsType {
                 <p>
                   The {{remoteId}} is used for looking up the remote
                   {{RTCRemoteInboundRtpStreamStats}} object for the same <a>SSRC</a>.
-                </p>
-              </dd>
-              <dt>
-                <dfn>rid</dfn> of type <span class="idlMemberType">DOMString</span>
-              </dt>
-              <dd>
-                <p>
-                  Exposes the {{RTCRtpCodingParameters/rid}}
-                  encoding parameter of this <a>RTP stream</a> if it has been set, otherwise it is
-                  undefined. If set this value will be present regardless if the RID RTP header
-                  extension has been negotiated.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
One of the steps needed for #621.

> AFTER THIS PR HAS BEEN APPROVED BUT BEFORE LANDING IT:
> Create a corresponding webrtc-provisional-stats PR adding these metrics to that document instead.

Chrome implemented simulcast stats, but it's not possible to say which layer an outbound-rtp stream belongs to other than sorting by size.

Should we remove it or fix Chrome?