### PR TITLE
Remove transport.rtcpTransportStatsId

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3516,13 +3516,10 @@ enum RTCStatsType {
         <p>
           An {{RTCTransportStats}} object represents the stats corresponding to an
           {{RTCDtlsTransport}} and its underlying
-          {{RTCIceTransport}}. When RTCP multiplexing is used, one transport is
-          used for both RTP and RTCP. Otherwise, RTP and RTCP will be sent on separate transports,
-          and {{RTCTransportStats/rtcpTransportStatsId}} can be used to pair the resulting
-          {{RTCTransportStats}} objects. Additionally, when bundling is used, a single
+          {{RTCIceTransport}}. When bundling is used, a single
           transport will be used for all {{MediaStreamTrack}}s in the bundle group.
           If bundling is not used, different {{MediaStreamTrack}} will use
-          different transports. RTCP multiplexing and bundling are described in [[!WEBRTC]].
+          different transports. Bundling are described in [[!WEBRTC]].
         </p>
         <div>
           <pre class="idl">dictionary RTCTransportStats : RTCStats {
@@ -3530,7 +3527,6 @@ enum RTCStatsType {
              unsigned long long    packetsReceived;
              unsigned long long    bytesSent;
              unsigned long long    bytesReceived;
-             DOMString             rtcpTransportStatsId;
              RTCIceRole            iceRole;
              DOMString             iceLocalUsernameFragment;
              required RTCDtlsTransportState dtlsState;
@@ -3588,17 +3584,6 @@ enum RTCStatsType {
                   Represents the total number of payload bytes received on this
                   {{RTCIceTransport}}, i.e., not including headers, padding
                   or ICE connectivity checks.
-                </p>
-              </dd>
-              <dt>
-                <dfn>rtcpTransportStatsId</dfn> of type <span class=
-                "idlMemberType">DOMString</span>
-              </dt>
-              <dd>
-                <p>
-                  If RTP and RTCP are not multiplexed, this is the {{RTCStats/id}} of the transport
-                  that gives stats for the RTCP component, and this record has only the RTP
-                  component stats.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2644,7 +2644,7 @@ enum RTCStatsType {
           {{RTCIceTransport}}. When bundling is used, a single
           transport will be used for all {{MediaStreamTrack}}s in the bundle group.
           If bundling is not used, different {{MediaStreamTrack}} will use
-          different transports. Bundling are described in [[!WEBRTC]].
+          different transports. Bundling is described in [[!WEBRTC]].
         </p>
         <div>
           <pre class="idl">dictionary RTCTransportStats : RTCStats {


### PR DESCRIPTION
One of the steps needed for #621.

> AFTER THIS PR HAS BEEN APPROVED BUT BEFORE LANDING IT:
> Create a corresponding webrtc-provisional-stats PR adding these metrics to that document instead.

As far as I understand, all implementations do RTCP multiplexing and there is never any need to have multiple transport stats objects.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/625.html" title="Last updated on Jun 9, 2022, 2:19 PM UTC (8a3c2cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/625/643d3f0...henbos:8a3c2cb.html" title="Last updated on Jun 9, 2022, 2:19 PM UTC (8a3c2cb)">Diff</a>