### PR TITLE
Remove remote-inbound-rtp.packetsDiscarded.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -964,7 +964,6 @@ enum RTCStatsType {
              unsigned long long   packetsReceived;
              long long            packetsLost;
              double               jitter;
-             unsigned long long   packetsDiscarded;
              unsigned long long   packetsRepaired;
              unsigned long long   burstPacketsLost;
              unsigned long long   burstPacketsDiscarded;
@@ -1017,18 +1016,6 @@ enum RTCStatsType {
                 <p>
                   Packet Jitter measured in seconds for this <a>SSRC</a>. Calculated as defined in section
                   6.4.1. of [[!RFC3550]].
-                </p>
-              </dd>
-              <dt>
-                <dfn>packetsDiscarded</dfn> of type <span class=
-                "idlMemberType">unsigned long long</span>
-              </dt>
-              <dd>
-                <p>
-                  The cumulative number of RTP packets discarded by the jitter buffer due to late
-                  or early-arrival, i.e., these packets are not played out. RTP packets discarded
-                  due to packet duplication are not reported in this metric [[XRBLOCK-STATS]].
-                  Calculated as defined in [[!RFC7002]] section 3.2 and Appendix A.a.
                 </p>
               </dd>
               <dt>
@@ -1197,6 +1184,7 @@ enum RTCStatsType {
              DOMHighResTimeStamp  lastPacketReceivedTimestamp;
              double               averageRtcpInterval;
              unsigned long long   headerBytesReceived;
+             unsigned long long   packetsDiscarded;
              unsigned long long   fecPacketsReceived;
              unsigned long long   fecPacketsDiscarded;
              unsigned long long   bytesReceived;
@@ -1423,6 +1411,18 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
+                <dfn>packetsDiscarded</dfn> of type <span class=
+                "idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  The cumulative number of RTP packets discarded by the jitter buffer due to late
+                  or early-arrival, i.e., these packets are not played out. RTP packets discarded
+                  due to packet duplication are not reported in this metric [[XRBLOCK-STATS]].
+                  Calculated as defined in [[!RFC7002]] section 3.2 and Appendix A.a.
+                </p>
+              </dd>
+              <dt>
                 <dfn>fecPacketsReceived</dfn> of type <span class=
                 "idlMemberType">unsigned long long</span>
               </dt>
@@ -1465,7 +1465,7 @@ enum RTCStatsType {
                 <p>
                   The cumulative number of RTP packets that failed to be decrypted according to the
                   procedures in [[!RFC3711]]. These packets are not counted by
-                  {{RTCReceivedRtpStreamStats/packetsDiscarded}}.
+                  {{RTCInboundRtpStreamStats/packetsDiscarded}}.
                 </p>
               </dd>
               <dt>
@@ -1474,7 +1474,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 The cumulative number of packets discarded because they are duplicated. Duplicate
-                packets are not counted in {{RTCReceivedRtpStreamStats/packetsDiscarded}}.<br>
+                packets are not counted in {{RTCInboundRtpStreamStats/packetsDiscarded}}.<br>
                 Duplicated packets have the same RTP sequence number and content as a previously
                 received packet. If multiple duplicates of a packet are received, all of them are
                 counted.<br>
@@ -1677,7 +1677,7 @@ enum RTCStatsType {
                   concealed sample is a sample that was replaced with synthesized samples generated
                   locally before being played out. Examples of samples that have to be concealed
                   are samples from lost packets (reported in {{RTCReceivedRtpStreamStats/packetsLost}}) or samples from packets that arrive
-                  too late to be played out (reported in {{RTCReceivedRtpStreamStats/packetsDiscarded}}).
+                  too late to be played out (reported in {{RTCInboundRtpStreamStats/packetsDiscarded}}).
                 </p>
                 
               </dd>


### PR DESCRIPTION
One of the steps needed for #621.

> AFTER THIS PR HAS BEEN APPROVED BUT BEFORE LANDING IT:
> Create a corresponding webrtc-provisional-stats PR adding these metrics to that document instead.

This one is implemented by RTCInboundRtpStreamStats but not by RTCRemoteInboundRtpStreamStats. In order to remove it from remote-inbound-rtp without removing it from inbound-rtp, the definition is moved from RTCReceivedRtpStreamStats to RTCInboundRtpStreamStats.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/626.html" title="Last updated on Jun 9, 2022, 1:21 PM UTC (d1bb8e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/626/68f614d...henbos:d1bb8e9.html" title="Last updated on Jun 9, 2022, 1:21 PM UTC (d1bb8e9)">Diff</a>