### PR TITLE
Remove sctp-transport

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -4533,10 +4533,6 @@ function processStats() {
             <td>{{RTCTransportStats}}</td>
           </tr>
           <tr>
-            <th class="row">{{RTCStatsType/"sctp-transport"}}</th>
-            <td>{{RTCSctpTransportStats}}</td>
-          </tr>
-          <tr>
             <th class="row">{{RTCStatsType/"candidate-pair"}}</th>
             <td>{{RTCIceCandidatePairStats}}</td>
           </tr>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -82,11 +82,7 @@
       <p>
         The terms {{RTCPeerConnection}}, {{RTCDataChannel}},
         {{RTCDtlsTransport}}, {{RTCDtlsTransportState}}, {{RTCIceTransport}},
-<<<<<<< HEAD
-        {{RTCIceRole}}, {{RTCDataChannelState}},
-=======
-        {{RTCIceRole}}, {{RTCIceTransportState}}, {{RTCSctpTransport}}, {{RTCDataChannelState}},
->>>>>>> main
+        {{RTCIceRole}}, {{RTCIceTransportState}}, {{RTCDataChannelState}},
         {{RTCIceCandidateType}},  {{RTCStats}}, {{RTCCertificate}} are defined in [[!WEBRTC]].
       </p>
       <p><dfn class=fixme data-idl>RTCPriorityType</dfn> is defined in [[WEBRTC-PRIORITY]].</p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -86,7 +86,7 @@
       <p>
         The terms {{RTCPeerConnection}}, {{RTCDataChannel}},
         {{RTCDtlsTransport}}, {{RTCDtlsTransportState}}, {{RTCIceTransport}},
-        {{RTCIceRole}}, {{RTCSctpTransport}}, {{RTCDataChannelState}},
+        {{RTCIceRole}}, {{RTCDataChannelState}},
         {{RTCIceCandidateType}},  {{RTCStats}}, {{RTCCertificate}} are defined in [[!WEBRTC]].
       </p>
       <p><dfn class=fixme data-idl>RTCPriorityType</dfn> is defined in [[WEBRTC-PRIORITY]].</p>
@@ -400,7 +400,6 @@ enum RTCStatsType {
 "sender",
 "receiver",
 "transport",
-"sctp-transport",
 "candidate-pair",
 "local-candidate",
 "remote-candidate",
@@ -587,16 +586,6 @@ enum RTCStatsType {
             <p>
               Transport statistics related to the {{RTCPeerConnection}} object. It is
               accessed by the {{RTCTransportStats}}.
-            </p>
-          </dd>
-          <dt>
-            <dfn>sctp-transport</dfn>
-          </dt>
-          <dd>
-            <p>
-              SCTP transport statistics related to an
-              {{RTCSctpTransport}} object. It is accessed by the
-              {{RTCSctpTransportStats}} dictionary.
             </p>
           </dd>
           <dt>
@@ -3729,99 +3718,6 @@ enum RTCStatsType {
                   selected candidate pair, or the other way around, also increases this
                   counter. It is initially zero and becomes one when an initial candidate
                   pair is selected.
-                </p>
-              </dd>
-            </dl>
-          </section>
-        </div>
-      </section>
-      <section id="sctptransportstats-dict*">
-        <h3>
-          <dfn>RTCSctpTransportStats</dfn> dictionary
-        </h3>
-        <p>
-          An {{RTCSctpTransportStats}} object represents the stats
-          corresponding to an {{RTCSctpTransport}} described in
-          [[!WEBRTC]].
-        </p>
-        <p>
-          There is only one {{RTCSctpTransportStats}} object, since the PeerConnection
-          can only have one SCTP transport.
-        </p>
-        <div>
-          <pre class="idl">dictionary RTCSctpTransportStats : RTCStats {
-            DOMString transportId;
-            double smoothedRoundTripTime;
-            unsigned long congestionWindow;
-            unsigned long receiverWindow;
-            unsigned long mtu;
-            unsigned long unackData;
-};</pre>
-          <section>
-            <h2>
-              Dictionary {{RTCSctpTransportStats}} Members
-            </h2>
-            <dl data-link-for="RTCSctpTransportStats" data-dfn-for="RTCSctpTransportStats" class=
-                "dictionary-members">
-              <dt>
-                <dfn>transportId</dfn> of type DOMString
-              </dt>
-              <dd>
-                <p>
-                  The identifier of the object that was inspected to produce the {{RTCTransportStats}}
-                  for the DTLSTransport and ICETransport supporting the SCTP transport.
-                </p>
-              </dd>
-              <dt>
-                <dfn>smoothedRoundTripTime</dfn> of type
-                <span class="idlMemberType">double</span>
-              </dt>
-              <dd>
-                <p>
-                  The latest smoothed round-trip time value, corresponding to
-                  spinfo_srtt defined in [[RFC6458]] but converted to seconds.
-                  If there has been no round-trip time measurements yet, this
-                  value is undefined.
-                </p>
-              </dd>
-              <dt>
-                <dfn>congestionWindow</dfn> of type
-                <span class="idlMemberType">unsigned long</span>
-              </dt>
-              <dd>
-                <p>
-                  The latest congestion window, corresponding to
-                  spinfo_cwnd defined in [[RFC6458]].
-                </p>
-              </dd>
-              <dt>
-                <dfn>receiverWindow</dfn> of type
-                <span class="idlMemberType">unsigned long</span>
-              </dt>
-              <dd>
-                <p>
-                  The latest receiver window, corresponding to
-                  sstat_rwnd defined in [[RFC6458]].
-                </p>
-              </dd>
-              <dt>
-                <dfn>mtu</dfn> of type
-                <span class="idlMemberType">unsigned long</span>
-              </dt>
-              <dd>
-                <p>
-                  The latest maximum transmission unit, corresponding to
-                  spinfo_mtu defined in [[RFC6458]].
-                </p>
-              </dd>
-              <dt>
-                <dfn>unackData</dfn> of type
-                <span class="idlMemberType">unsigned long</span>
-              </dt>
-              <dd>
-                <p>
-                  The number of unacknowledged DATA chunks, corresponding to
-                  sstat_unackdata defined in [[RFC6458]].
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
One of the steps needed for #621.

> AFTER THIS PR HAS BEEN APPROVED BUT BEFORE LANDING IT:
> Create a corresponding webrtc-provisional-stats PR adding these metrics to that document instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/627.html" title="Last updated on Jun 9, 2022, 1:40 PM UTC (29695b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/627/af5fb42...henbos:29695b2.html" title="Last updated on Jun 9, 2022, 1:40 PM UTC (29695b2)">Diff</a>