### PR TITLE
Fix definitions to make respec happy

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -80,10 +80,6 @@
         Terminology
       </h2>
       <p>
-        The terms <dfn>MediaStream</dfn>, <dfn>MediaStreamTrack</dfn>, and <dfn>Consumer</dfn> are
-        defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
         The terms {{RTCPeerConnection}}, {{RTCDataChannel}},
         {{RTCDtlsTransport}}, {{RTCDtlsTransportState}}, {{RTCIceTransport}},
         {{RTCIceRole}}, {{RTCSctpTransport}}, {{RTCDataChannelState}},

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3451,13 +3451,6 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn>transportId</dfn> of type <span class=
-                "idlMemberType">DOMString</span>
-              </dt>
-              <dd>
-                A [= stats object reference =] for the transport used to carry this datachannel.
-              </dd>
-              <dt>
                 <dfn>state</dfn> of type {{RTCDataChannelState}}
               </dt>
               <dd>

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -1,7 +1,9 @@
+let aMonthFromNow = new Date();
+aMonthFromNow.setMonth(aMonthFromNow.getMonth() + 1);
 var respecConfig = {
       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
       specStatus:           "ED",
-
+      crEnd: aMonthFromNow.toJSON().slice(0,10),
       // the specification's short name, as in http://www.w3.org/TR/short-name/
       shortName:            "webrtc-stats",
 


### PR DESCRIPTION
should unbreak CI


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/pull/630.html" title="Last updated on Apr 21, 2022, 7:15 PM UTC (f4b969e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/630/6c49aeb...f4b969e.html" title="Last updated on Apr 21, 2022, 7:15 PM UTC (f4b969e)">Diff</a>