### PR TITLE
Improve markup of enumeration tables

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -918,12 +918,13 @@ enum RTCStatsType {
     "decode",
 };</pre>
             <table data-link-for="RTCCodecType" data-dfn-for="RTCCodecType" class="simple">
-              <tbody>
+	      <caption>{{RTCCodecType}} Enumeration description</caption>
+              <thead>
                 <tr>
-                  <th colspan="2">
-                    Enumeration description
-                  </th>
+		  <th>Enum value</th><th>Description</th>
                 </tr>
+	      </thead>
+	      <tbody>
                 <tr>
                   <td>
                     <dfn>encode</dfn>
@@ -2538,13 +2539,14 @@ enum RTCStatsType {
             "other",
           };</pre>
           <table data-link-for="RTCQualityLimitationReason" data-dfn-for=
-          "RTCQualityLimitationReason" class="simple">
-            <tbody>
+		 "RTCQualityLimitationReason" class="simple">
+	    <caption>{{RTCQualityLimitationReason}} Enumeration description</caption>
+            <thead>
               <tr>
-                <th colspan="2">
-                  Enumeration description
-                </th>
+		<th>Enum value</th><th>Description</th>
               </tr>
+	    </thead>
+	    <tbody>
               <tr>
                 <td>
                   <dfn>none</dfn>
@@ -3744,12 +3746,13 @@ enum RTCStatsType {
         "unknown",
 };</pre>
                 <table data-link-for="RTCDtlsRole" data-dfn-for="RTCDtlsRole" class="simple">
-                  <tbody>
+		  <caption>{{RTCDtlsRole}} Enumeration description</caption>
+                  <thead>
                     <tr>
-                      <th colspan="2">
-                        Enumeration description
-                      </th>
+		      <th>Enum value</th><th>Description</th>
                     </tr>
+		  </thead>
+		  <tbody>
                     <tr>
                       <td>
                         <dfn>client</dfn>
@@ -4416,13 +4419,14 @@ enum RTCStatsType {
     "succeeded"
 };</pre>
             <table data-link-for="RTCStatsIceCandidatePairState" data-dfn-for=
-            "RTCStatsIceCandidatePairState" class="simple">
-              <tbody>
+		   "RTCStatsIceCandidatePairState" class="simple">
+	      <caption>{{RTCStatsIceCandidatePairState}} Enumeration description</caption>
+              <thead>
                 <tr>
-                  <th colspan="2">
-                    Enumeration description
-                  </th>
+		  <th>Enum value</th><th>Description</th>
                 </tr>
+	      </thead>
+	      <tbody>
                 <tr>
                   <td>
                     <dfn>frozen</dfn>


### PR DESCRIPTION
see also https://github.com/w3c/media-source/issues/307#issuecomment-1110865467


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 28, 2022, 12:55 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebrtc-stats%2F4f36fd9714101736d6532a5beddac7fad8ae5084%2Fwebrtc-stats.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/iINKJg
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-stats%23631.)._
</details>
