### PR TITLE
Spelling Corrected

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2112,7 +2112,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Total number of RTP packets for this <a>SSRC</a> that have been discarded due to socket
-                  errors, i.e. a socket error occured when handing the packets to the socket. This
+                  errors, i.e. a socket error occurred when handing the packets to the socket. This
                   might happen due to various reasons, including full buffer or no available
                   memory.
                 </p>
@@ -2124,7 +2124,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Total number of bytes for this <a>SSRC</a> that have been discarded due to socket
-                  errors, i.e. a socket error occured when handing the packets containing the bytes
+                  errors, i.e. a socket error occurred when handing the packets containing the bytes
                   to the socket. This might happen due to various reasons, including full buffer or
                   no available memory. Calculated as defined in [[!RFC3550]] section 6.4.1.
                 </p>
@@ -2295,7 +2295,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Total number of video frames that have been discarded for this <a>SSRC</a> due to socket
-                  errors, i.e. a socket error occured when handing the packets to the socket. This
+                  errors, i.e. a socket error occurred when handing the packets to the socket. This
                   might happen due to various reasons, including full buffer or no available
                   memory. 
                 </p>
@@ -4359,7 +4359,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Total number of  packets for this candidate pair that have been discarded due to socket
-                  errors, i.e. a socket error occured when handing the packets to the socket. This
+                  errors, i.e. a socket error occurred when handing the packets to the socket. This
                   might happen due to various reasons, including full buffer or no available
                   memory.
                 </p>
@@ -4371,7 +4371,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Total number of bytes for this candidate pair that have been discarded due to socket
-                  errors, i.e. a socket error occured when handing the packets containing the bytes
+                  errors, i.e. a socket error occurred when handing the packets containing the bytes
                   to the socket. This might happen due to various reasons, including full buffer or
                   no available memory. Calculated as defined in [[!RFC3550]] section 6.4.1.
                 </p>


### PR DESCRIPTION
The spelling of occurred was mentioned as occured at some different places.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shivam7374/webrtc-stats/pull/635.html" title="Last updated on Jun 7, 2022, 6:20 AM UTC (3e69ebe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/635/c78394f...shivam7374:3e69ebe.html" title="Last updated on Jun 7, 2022, 6:20 AM UTC (3e69ebe)">Diff</a>