### PR TITLE
Fix typo

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3211,7 +3211,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Total number of  packets for this candidate pair that have been discarded due to socket
-                  errors, i.e. a socket error occured when handing the packets to the socket. This
+                  errors, i.e. a socket error occurred when handing the packets to the socket. This
                   might happen due to various reasons, including full buffer or no available
                   memory.
                 </p>
@@ -3223,7 +3223,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Total number of bytes for this candidate pair that have been discarded due to socket
-                  errors, i.e. a socket error occured when handing the packets containing the bytes
+                  errors, i.e. a socket error occurred when handing the packets containing the bytes
                   to the socket. This might happen due to various reasons, including full buffer or
                   no available memory. Calculated as defined in [[!RFC3550]] section 6.4.1.
                 </p>


### PR DESCRIPTION
This is a copy of https://github.com/w3c/webrtc-stats/pull/635 but with resolved conflicts


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/639.html" title="Last updated on Jun 14, 2022, 1:30 PM UTC (61dcab9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/639/2b91d79...henbos:61dcab9.html" title="Last updated on Jun 14, 2022, 1:30 PM UTC (61dcab9)">Diff</a>