### PR TITLE
Add estimatedMinimumJitterBufferTargetDelay metric (#634)

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -926,6 +926,7 @@ enum RTCStatsType {
              double               jitterBufferDelay;
              double               jitterBufferTargetDelay;
              unsigned long long   jitterBufferEmittedCount;
+             double               estimatedMinimumJitterBufferTargetDelay;
              unsigned long long   totalSamplesReceived;
              unsigned long long   concealedSamples;
              unsigned long long   silentConcealedSamples;
@@ -1292,6 +1293,26 @@ enum RTCStatsType {
                   jitter buffer (increasing {{jitterBufferDelay}}).
                 </p>
                 
+              </dd>
+              <dt>
+                <dfn>estimatedMinimumJitterBufferTargetDelay</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  There are various reasons why the jitter buffer delay might be increased to a higher value, such as
+                  to achieve AV synchronization or because a
+                  <a href="https://w3c.github.io/webrtc-extensions/#dom-rtcrtpreceiver-playoutdelay">playoutDelay</a>
+                  was set on a RTCRtpReceiver. When using one of these mechanisms, it can be useful to keep track of
+                  the minimal jitter buffer delay that could have been achieved, so WebRTC clients can track the amount
+                  of additional delay that is being added.
+                </p><p>
+                  This metric works the same way as {{jitterBufferTargetDelay}}, except that it is not affected by
+                  external mechanisms that increase the jitter buffer target delay, such as playoutDelay (see link above),
+                  AV sync, or any other mechanisms. This metric is purely based on the network characteristics such
+                  as jitter and packet loss, and can be seen as the minimum obtainable jitter buffer delay if no
+                  external factors would affect it.
+                </p>
               </dd>
               <dt>
                 <dfn>totalSamplesReceived</dfn> of type <span class=


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ivocreusen/webrtc-stats/pull/640.html" title="Last updated on Jun 15, 2022, 2:59 PM UTC (a36cf7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/640/70b92b8...ivocreusen:a36cf7a.html" title="Last updated on Jun 15, 2022, 2:59 PM UTC (a36cf7a)">Diff</a>