### PR TITLE
outbound-rtp: add active flag

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1659,6 +1659,7 @@ enum RTCStatsType {
              unsigned long        firCount;
              unsigned long        pliCount;
              DOMString            encoderImplementation;
+             boolean              active;
 };</pre>
           <section>
             <h2>
@@ -2003,6 +2004,17 @@ enum RTCStatsType {
                 <p class="fingerprint">
                   If too much information is given here, it increases the fingerprint surface.
                   Since it is only given for active tracks, the incremental exposure is small.
+                </p>
+              </dd>
+              <dt>
+                <dfn>active</dfn> of type <span class=
+                "idlMemberType">boolean</span>
+              </dt>
+              <dd>
+                <p>
+                  Indicates whether this <a>RTP stream</a> is configured to be sent or disabled.
+                  Note that an active stream can still not be sending, e.g. when being limited by
+                  network conditions.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
exposing
  https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters-active
in stats as well.

Fixes #597


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/649.html" title="Last updated on Jul 22, 2022, 3:24 PM UTC (1eb96f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/649/dc3120a...fippo:1eb96f8.html" title="Last updated on Jul 22, 2022, 3:24 PM UTC (1eb96f8)">Diff</a>