### PR TITLE
make encoderImplementation/decoderImplementation video-only

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1632,8 +1632,8 @@ enum RTCStatsType {
                   Only defined when [= exposing hardware is allowed =].
                 </p>
                 <p>
-                  Identifies the decoder implementation used. This is useful for
-                  diagnosing interoperability issues.
+                  Only [= map/exist =]s for video. Identifies the decoder implementation used.
+                  This is useful for diagnosing interoperability issues.
                 </p>
               </dd>
               <dt>
@@ -2167,8 +2167,8 @@ enum RTCStatsType {
                   Only defined when [= exposing hardware is allowed =].
                 </p>
                 <p>
-                  Identifies the encoder implementation used. This is useful for diagnosing
-                  interoperability issues.
+                  Only [= map/exist =]s for video. Identifies the encoder implementation used.
+                  This is useful for diagnosing interoperability issues.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
fixes #638


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 4, 2022, 1:44 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Ffippo%2Fwebrtc-stats%2Fdc500ac21a3fc1bbdedbad33edb8dcdad291d439%2Fwebrtc-stats.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-stats%23654.)._
</details>
