### PR TITLE
relayProtocol: use RTCIceServerTransportProtocol struct

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2871,7 +2871,7 @@ enum RTCStatsType {
              required RTCIceCandidateType candidateType;
              long                     priority;
              DOMString                url;
-             DOMString                relayProtocol;
+             RTCIceServerTransportProtocol relayProtocol;
 };</pre>
           <section>
             <h2>
@@ -2961,13 +2961,12 @@ enum RTCStatsType {
               </dd>
               <dt>
                 <dfn>relayProtocol</dfn> of type <span class=
-                "idlMemberType">DOMString</span> <!-- TODO: define enum? -->
+                "idlMemberType">{{RTCIceServerTransportProtocol}}</span>
               </dt>
               <dd>
                 <p>
                   It is the protocol used by the endpoint to communicate with the TURN server. This
-                  is only present for local relay candidates. Valid values are <code>"udp"</code>,
-                  <code>"tcp"</code>, or <code>"tls"</code>.
+                  is only present for local relay candidates and defined in [[WEBRTC]].
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2966,7 +2966,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   It is the protocol used by the endpoint to communicate with the TURN server. This
-                  is only present for local candidates. Valid values are <code>"udp"</code>,
+                  is only present for local relay candidates. Valid values are <code>"udp"</code>,
                   <code>"tcp"</code>, or <code>"tls"</code>.
                 </p>
               </dd>


### PR DESCRIPTION
following
  https://github.com/w3c/webrtc-pc/pull/2763


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/657.html" title="Last updated on Sep 22, 2022, 3:56 PM UTC (7cb54bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/657/b708dd3...fippo:7cb54bb.html" title="Last updated on Sep 22, 2022, 3:56 PM UTC (7cb54bb)">Diff</a>