### PR TITLE
Only expose RTCCodecStats objects currently in use

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -734,10 +734,23 @@ enum RTCStatsType {
           <dfn>RTCCodecStats</dfn> dictionary
         </h3>
         <p>
-          This object is created when a codec type is registered for
-          an RTP transport. It may be referenced by multiple RTP streams
-          in media sections using that transport, but similar codecs in
-          different transports have different RTCCodecStats objects.
+          Codecs are created when registered for an RTP transport,
+          but only the subset of codecs that are in use (referenced by an RTP
+          stream) are exposed in <code>getStats()</code>.
+        </p>
+        <p>
+          The {{RTCCodecStats}} object is created when one or more
+          <code>RTCOutboundRtpStreamStats.codecId</code> or
+          <code>RTCInboundRtpStreamStats.codecId</code> references the codec
+          stats object. When there no longer exists any reference to the
+          {{RTCCodecStats}}, the stats object is deleted. If the same codec is
+          used again in the future, the {{RTCCodecStats}} object is revived with
+          the same {{RTCStats/id}} as before.
+        </p>
+        <p>
+          Codec objects may be referenced by multiple RTP streams in
+          media sections using the same transport, but similar codecs in
+          different transports have different {{RTCCodecStats}} objects.
         </p>
         <p class="note">
           User agents are expected to coalesce information into a single

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -740,12 +740,11 @@ enum RTCStatsType {
         </p>
         <p>
           The {{RTCCodecStats}} object is created when one or more
-          <code>RTCOutboundRtpStreamStats.codecId</code> or
-          <code>RTCInboundRtpStreamStats.codecId</code> references the codec
-          stats object. When there no longer exists any reference to the
-          {{RTCCodecStats}}, the stats object is deleted. If the same codec is
-          used again in the future, the {{RTCCodecStats}} object is revived with
-          the same {{RTCStats/id}} as before.
+          {{RTCRtpStreamStats/codecId}} references the codec. When there no
+          longer exists any reference to the {{RTCCodecStats}}, the stats object
+          is deleted. If the same codec is used again in the future, the
+          {{RTCCodecStats}} object is revived with the same {{RTCStats/id}} as
+          before.
         </p>
         <p>
           Codec objects may be referenced by multiple RTP streams in


### PR DESCRIPTION
Fixes #662


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/669.html" title="Last updated on Sep 7, 2022, 12:56 PM UTC (0d6a871)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/669/b708dd3...henbos:0d6a871.html" title="Last updated on Sep 7, 2022, 12:56 PM UTC (0d6a871)">Diff</a>