### PR TITLE
Make RTP creation dependent on SSRC being known rather than packet being sent

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -612,7 +612,8 @@ enum RTCStatsType {
           is known. For send streams, the SSRC is decided when setting the SDP
           offer. For receive streams, the SSRC is typically known after
           receiving the first packet, however if the SSRC is signalled via SDP
-          then the RTP stream is created when the remote SDP is set.
+          then the RTP stream is created when the remote SDP is set containing
+          the SSRC information.
         </p>
         <p>
           RTP monitored objects are not [= deleted =].

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -607,9 +607,12 @@ enum RTCStatsType {
           RTCP SR or RR block.
         </p>
         <p>
-          The lifetime of all RTP [= monitored object =]s starts when the <a>RTP stream</a> is first
-          used: When the first RTP packet is sent or received on the <a>SSRC</a> it represents, or when
-          the first RTCP packet is sent or received that refers to the <a>SSRC</a> of the <a>RTP stream</a>.
+          The lifetime of all RTP [= monitored object =]s starts when the <a>RTP
+          stream</a> is first configured and the required <a>SSRC</a> attribute
+          is known. For send streams, the SSRC is decided when setting the SDP
+          offer. For receive streams, the SSRC is typically known after
+          receiving the first packet, however if the SSRC is signalled via SDP
+          then the RTP stream is created when the remote SDP is set.
         </p>
         <p>
           RTP monitored objects are not [= deleted =].


### PR DESCRIPTION
Fixes #667.

This matches Chromium, which for example exposes outbound-rtp after setLocalDescription, even if ICE is not connected and packetsSent is 0. I hope all browsers align here but I'm not sure.

**EDIT:** Maybe we should just abandon this and update the implementation, see discussion below


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/671.html" title="Last updated on Sep 7, 2022, 2:26 PM UTC (0669acd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/671/b708dd3...henbos:0669acd.html" title="Last updated on Sep 7, 2022, 2:26 PM UTC (0669acd)">Diff</a>