### PR TITLE
Add RTCAudioPlayoutStats, synthesizedSamplesDuration and totalSamplesDuration

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -948,6 +948,7 @@ enum RTCStatsType {
              double               totalSamplesDuration;
              unsigned long        framesReceived;
              DOMString            decoderImplementation;
+             DOMString            playoutId;
             };</pre>
           <section>
             <h2>
@@ -1503,6 +1504,16 @@ enum RTCStatsType {
                 <p class="fingerprint">
                   If too much information is given here, it increases the fingerprint surface.
                   Since it is only given for active tracks, the incremental exposure is small.
+                </p>
+              </dd>
+              <dt>
+                <dfn>playoutId</dfn> of type <span class=
+                "idlMemberType">DOMString</span>
+              </dt>
+              <dd>
+                <p>
+                  If audio playout is happening, this is used to look up the
+                  corresponding {{RTCAudioPlayoutStats}}.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2498,7 +2498,8 @@ enum RTCStatsType {
           Only applicable if the playout path represents an audio devcice.
           Represents one playout path. If the same playout stats object is
           referenced by multiple {{RTCInboundRtpStreamStats}} this is an
-          indication that audio mixing is happening.
+          indication that audio mixing is happening in which case sample
+          counters in this stats object refer to samples after mixing.
         </p>
         <div>
           <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
@@ -2525,6 +2526,12 @@ enum RTCStatsType {
                   {{totalSamplesDuration}} to calculate the percentage of played
                   out media being synthesized.
                 </p>
+                <p>
+                  Synthesization typically only happens if the pipeline is
+                  underperforming. Samples synthesized by the
+                  {{RTCInboundRtpStreamStats}} are not counted for here, but in
+                  {{RTCInboundRtpStreamStats}}.{{RTCInboundRtpStreamStats/concealedSamples}}.
+                </p>
               </dd>
               <dt>
                 <dfn>totalSamplesDuration</dfn> of type <span class=
@@ -2533,7 +2540,8 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The total duration, in seconds, of all audio samples that have
-                  been playout.
+                  been playout. Includes both synthesized and non-synthesized
+                  samples.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -382,6 +382,7 @@ enum RTCStatsType {
 "remote-inbound-rtp",
 "remote-outbound-rtp",
 "media-source",
+"media-playout",
 "peer-connection",
 "data-channel",
 "stream",
@@ -472,6 +473,15 @@ enum RTCStatsType {
               (i.e. not the raw media produced by the camera). It is either an
               {{RTCAudioSourceStats}} or {{RTCVideoSourceStats}}
               depending on its <code class=gum>kind</code>.
+            </p>
+          </dd>
+          <dt>
+            <dfn>media-playout</dfn>
+          </dt>
+          <dd>
+            <p>
+              Statistics related to audio playout. It is accessed by the
+              {{RTCAudioPlayoutStats}}.
             </p>
           </dd>
           <dt>
@@ -2456,6 +2466,55 @@ enum RTCStatsType {
           </section>
         </div>
       </section>
+
+      <section id="playoutstats-dict*">
+        <h3>
+          {{RTCAudioPlayoutStats}} dictionary
+        </h3>
+        <p>
+          Only applicable if the playout path represents an audio devcice.
+          Represents one playout path, which may or may not be after mixing.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
+             required double synthesizedSamplesDuration;
+             required double totalSamplesDuration;
+};</pre>
+          <section>
+            <h2>
+              Dictionary {{RTCAudioPlayoutStats}} Members
+            </h2>
+            <dl data-link-for="RTCAudioPlayoutStats" data-dfn-for="RTCAudioPlayoutStats" class=
+            "dictionary-members">
+              <dt>
+                <dfn>synthesizedSamplesDuration</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  If the playout path is unable to produce audio samples on time
+                  for device playout, samples are synthesized to be playout out
+                  instead. {{synthesizedSamplesDuration}} is incremented each
+                  time this happens. Can be used together with
+                  {{totalSamplesDuration}} to calculate the percentage of media
+                  played out being synthesized.
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalSamplesDuration</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  The total duration, in seconds, of all audio samples that have
+                  been playout.
+                </p>
+              </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+
 <section id="pcstats-dict*">
         <h3>
           <dfn>RTCPeerConnectionStats</dfn> dictionary

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2477,8 +2477,8 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
-             required double synthesizedSamplesDuration;
-             required double totalSamplesDuration;
+             double synthesizedSamplesDuration;
+             double totalSamplesDuration;
 };</pre>
           <section>
             <h2>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2484,7 +2484,9 @@ enum RTCStatsType {
         </h3>
         <p>
           Only applicable if the playout path represents an audio devcice.
-          Represents one playout path, which may or may not be after mixing.
+          Represents one playout path. If the same playout stats object is
+          referenced by multiple {{RTCInboundRtpStreamStats}} this is an
+          indication that audio mixing is happening.
         </p>
         <div>
           <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
@@ -2505,10 +2507,11 @@ enum RTCStatsType {
                 <p>
                   If the playout path is unable to produce audio samples on time
                   for device playout, samples are synthesized to be playout out
-                  instead. {{synthesizedSamplesDuration}} is incremented each
-                  time this happens. Can be used together with
-                  {{totalSamplesDuration}} to calculate the percentage of media
-                  played out being synthesized.
+                  instead. {{synthesizedSamplesDuration}} is measured in seconds
+                  and is incremented each time an audio sample is synthesized by
+                  this playout path. This metric can be used together with
+                  {{totalSamplesDuration}} to calculate the percentage of played
+                  out media being synthesized.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Fixes #676


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/682.html" title="Last updated on Sep 20, 2022, 2:54 PM UTC (85d77f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/682/072f9dd...henbos:85d77f1.html" title="Last updated on Sep 20, 2022, 2:54 PM UTC (85d77f1)">Diff</a>