### PR TITLE
Add totalPlayoutDelay and totalSamplesCount to RTCAudioPlayoutStats.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -382,6 +382,7 @@ enum RTCStatsType {
 "remote-inbound-rtp",
 "remote-outbound-rtp",
 "media-source",
+"media-playout",
 "peer-connection",
 "data-channel",
 "stream",
@@ -472,6 +473,15 @@ enum RTCStatsType {
               (i.e. not the raw media produced by the camera). It is either an
               {{RTCAudioSourceStats}} or {{RTCVideoSourceStats}}
               depending on its <code class=gum>kind</code>.
+            </p>
+          </dd>
+          <dt>
+            <dfn>media-playout</dfn>
+          </dt>
+          <dd>
+            <p>
+              Statistics related to audio playout. It is accessed by the
+              {{RTCAudioPlayoutStats}}.
             </p>
           </dd>
           <dt>
@@ -2456,6 +2466,55 @@ enum RTCStatsType {
           </section>
         </div>
       </section>
+
+      <section id="playoutstats-dict*">
+        <h3>
+          {{RTCAudioPlayoutStats}} dictionary
+        </h3>
+        <p>
+          Only applicable if the playout path represents an audio devcice.
+          Represents one playout path, which may or may not be after mixing.
+        </p>
+        <div>
+          <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
+             required double synthesizedSamplesDuration;
+             required double totalSamplesDuration;
+};</pre>
+          <section>
+            <h2>
+              Dictionary {{RTCAudioPlayoutStats}} Members
+            </h2>
+            <dl data-link-for="RTCAudioPlayoutStats" data-dfn-for="RTCAudioPlayoutStats" class=
+            "dictionary-members">
+              <dt>
+                <dfn>synthesizedSamplesDuration</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  If the playout path is unable to produce audio samples on time
+                  for device playout, samples are synthesized to be playout out
+                  instead. {{synthesizedSamplesDuration}} is incremented each
+                  time this happens. Can be used together with
+                  {{totalSamplesDuration}} to calculate the percentage of media
+                  played out being synthesized.
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalSamplesDuration</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  The total duration, in seconds, of all audio samples that have
+                  been playout.
+                </p>
+              </dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+
 <section id="pcstats-dict*">
         <h3>
           <dfn>RTCPeerConnectionStats</dfn> dictionary

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2477,8 +2477,8 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
-             required double synthesizedSamplesDuration;
-             required double totalSamplesDuration;
+             double synthesizedSamplesDuration;
+             double totalSamplesDuration;
 };</pre>
           <section>
             <h2>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2554,7 +2554,9 @@ enum RTCStatsType {
                 <p>
                   When audio samples are pulled by the playout device, this
                   counter is incremented with the estimated delay of the playout
-                  path for that audio sample. Can be used together with
+                  path for that audio sample. The playout delay includes the
+                  delay from being emitted to the actual time of playout on the
+                  device. This metric can be used together with
                   {{totalSamplesCount}} to calculate the average playout delay
                   per sample.
                 </p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2479,6 +2479,8 @@ enum RTCStatsType {
           <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
              double synthesizedSamplesDuration;
              double totalSamplesDuration;
+             double totalPlayoutDelay;
+             double totalSamplesCount;
 };</pre>
           <section>
             <h2>
@@ -2508,6 +2510,30 @@ enum RTCStatsType {
                 <p>
                   The total duration, in seconds, of all audio samples that have
                   been playout.
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalPlayoutDelay</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  When audio samples are pulled by the playout device, this
+                  counter is incremented with the estimated delay of the playout
+                  path for that audio sample. Can be used together with
+                  {{totalSamplesCount}} to calculate the average playout delay
+                  per sample.
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalSamplesCount</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  When audio samples are pulled by the playout device, this
+                  counter is incremented with the number of samples emitted for
+                  playout.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
Fixes #680.

NOTE This PR is made on top of #682. This PR only related to totalPlayoutDelay and totalSamplesCount.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/683.html" title="Last updated on Sep 20, 2022, 2:57 PM UTC (e211759)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/683/cfb8128...henbos:e211759.html" title="Last updated on Sep 20, 2022, 2:57 PM UTC (e211759)">Diff</a>