### PR TITLE
Add totalCaptureDelay and totalSamplesCaptured to RTCAudioSourceStats.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2447,23 +2447,25 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Only applicable if the audio source represents an audio
-                  capture device. This is the total delay for each audio sample
-                  between the time the sample was emitted by the capture device
-                  and the sample reaching the source. This can be used together
-                  with {{totalSamplesCaptured}} to calculate the average capture
-                  delay per sample.
+                  capture device. This is the total delay, in seconds, for each
+                  audio sample between the time the sample was emitted by the
+                  capture device and the sample reaching the source. This can be
+                  used together with {{totalSamplesCaptured}} to calculate the
+                  average capture delay per sample.
                 </p>
               </dd>
               <dt>
                 <dfn>totalSamplesCaptured</dfn> of type <span class=
-                "idlMemberType">double</span>
+                "idlMemberType">unsigned long long</span>
               </dt>
               <dd>
                 <p>
                   Only applicable if the audio source represents an audio
                   capture device. This is the total number of captured samples
                   reaching the audio source, i.e. that were not dropped by the
-                  capture pipeline.
+                  capture pipeline. The frequency of the media source is not
+                  necessarily the same as the frequency of encoders later in the
+                  pipeline.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2272,6 +2272,8 @@ enum RTCStatsType {
               double              totalSamplesDuration;
               double              echoReturnLoss;
               double              echoReturnLossEnhancement;
+              double              totalCaptureDelay;
+              unsigned long long  totalSamplesCaptured;
 };</pre>
           <section>
             <h2>
@@ -2386,6 +2388,32 @@ enum RTCStatsType {
                 <p>
                   If multiple audio channels are used, the channel of the
                   <strong>least audio energy</strong> is considered for any sample.
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalCaptureDelay</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  Only applicable if the audio source represents an audio
+                  capture device. This is the total delay for each audio sample
+                  between the time the sample was emitted by the capture device
+                  and the sample reaching the source. This can be used together
+                  with {{totalSamplesCaptured}} to calculate the average capture
+                  delay per sample.
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalSamplesCaptured</dfn> of type <span class=
+                "idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  Only applicable if the audio source represents an audio
+                  capture device. This is the total number of captured samples
+                  reaching the audio source, i.e. that were not dropped by the
+                  capture pipeline.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
Fixes #681


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/685.html" title="Last updated on Sep 20, 2022, 3:11 PM UTC (145be7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/685/a2b7577...henbos:145be7a.html" title="Last updated on Sep 20, 2022, 3:11 PM UTC (145be7a)">Diff</a>