### PR TITLE
Add droppedSamplesEvents and synthesizedSamplesEvents

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2306,6 +2306,7 @@ enum RTCStatsType {
               double              echoReturnLoss;
               double              echoReturnLossEnhancement;
               double              droppedSamplesDuration;
+              unsigned long       droppedSamplesEvents;
               double              totalCaptureDelay;
               unsigned long long  totalSamplesCaptured;
 };</pre>
@@ -2441,6 +2442,19 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
+                <dfn>droppedSamplesEvents</dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  The number of dropped samples events. This counter
+                  increases every time a sample is dropped after a non-dropped
+                  sample. That is, multiple consecutive dropped samples will
+                  increase {{droppedSamplesDuration}} multiple times but is a
+                  single dropped samples event.
+                </p>
+              </dd>
+              <dt>
                 <dfn>totalCaptureDelay</dfn> of type <span class=
                 "idlMemberType">double</span>
               </dt>
@@ -2550,10 +2564,11 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
-             double synthesizedSamplesDuration;
-             double totalSamplesDuration;
-             double totalPlayoutDelay;
-             double totalSamplesCount;
+             double        synthesizedSamplesDuration;
+             unsigned long synthesizedSamplesEvents;
+             double        totalSamplesDuration;
+             double        totalPlayoutDelay;
+             double        totalSamplesCount;
 };</pre>
           <section>
             <h2>
@@ -2580,6 +2595,20 @@ enum RTCStatsType {
                   underperforming. Samples synthesized by the
                   {{RTCInboundRtpStreamStats}} are not counted for here, but in
                   {{RTCInboundRtpStreamStats}}.{{RTCInboundRtpStreamStats/concealedSamples}}.
+                </p>
+              </dd>
+              <dt>
+                <dfn>synthesizedSamplesEvents</dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  The number of synthesized samples events. This counter
+                  increases every time a sample is synthesized after a
+                  non-synthesized sample. That is, multiple consecutive
+                  synthesized samples will increase
+                  {{synthesizedSamplesDuration}} multiple times but is a single
+                  synthesization samples event.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Fixes #677, #679.

Because sample drops and sample synthesization tend to happen in bursts it is useful to not only know the duration but also the number of "events" happened.

The definition for these are very similar to [concealmentEvents](https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-concealmentevents).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/688.html" title="Last updated on Sep 21, 2022, 9:20 AM UTC (391b21d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/688/8ae8a4c...henbos:391b21d.html" title="Last updated on Sep 21, 2022, 9:20 AM UTC (391b21d)">Diff</a>