### PR TITLE
inbound-rtp: add frame assembly time

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1023,8 +1023,8 @@ enum RTCStatsType {
              DOMString            decoderImplementation;
              DOMString            playoutId;
              boolean              powerEfficientDecoder;
-             double               totalAssemblyTime;
              unsigned long        framesAssembledFromMultiplePackets;
+             double               totalAssemblyTime;
             };</pre>
           <section>
             <h2>
@@ -1665,6 +1665,17 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
+                <dfn>framesAssembledFromMultiplePackets</dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  Only [= map/exist =]s for video.  It represents the total number of frames correctly decoded
+                  for this RTP stream that consist of more than one RTP packet. For such frames the
+                  {{totalAssemblyTime}} is incremented.
+                </p>
+              </dd>
+              <dt>
                 <dfn>totalAssemblyTime</dfn> of type <span class=
                 "idlMemberType">double</span>
               </dt>
@@ -1672,23 +1683,16 @@ enum RTCStatsType {
                 <p>
                   Only [= map/exist =]s for video. The sum of the time, in seconds, each video frame takes
                   from the time the first RTP packet is received (reception timestamp) and to the time
-                  the last RTP packet of a frame is received.
+                  the last RTP packet of a frame is received. Only incremented for frames consisting of more
+                  than one RTP packet.
                 </p>
                 <p>
-                  Given the complexities involved, the time of arrival or the reception timestamp is measured as close to the network layer as possible.
-                  This metric is not incremented for frames that are not decoded, i.e., framesDropped, partialFramesLost or frames that fail decoding
-                  for other reasons (if any). Only incremented for frames consisting of more than one RTP packet. The average frame assembly time can
-                  be calculated by dividing the totalAssemblyTime with framesAssembledFromMultiplePackets.
-                </p>
-              </dd>
-              <dt>
-                <dfn>framesAssembledFromMultiplePackets</dfn> of type <span class=
-                "idlMemberType">unsigned long</span>
-              </dt>
-              <dd>
-                <p>
-                  Only [= map/exist =]s for video.  It represents the total number of frames correctly decoded for this RTP stream that consist of
-                  more than one RTP packet. For such frames the totalAssemblyTime is incremented.
+                  Given the complexities involved, the time of arrival or the reception timestamp is measured
+                  as close to the network layer as possible. This metric is not incremented for frames that
+                  are not decoded, i.e., {{framesDropped}}, {{partialFramesLost}} or frames that fail decoding for
+                  other reasons (if any). Only incremented for frames consisting of more than one RTP packet.
+                  The average frame assembly time can be calculated by dividing the {{totalAssemblyTime}} with
+                  {{framesAssembledFromMultiplePackets}}.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1672,7 +1672,8 @@ enum RTCStatsType {
                 <p>
                   Only [= map/exist =]s for video.  It represents the total number of frames correctly decoded
                   for this RTP stream that consist of more than one RTP packet. For such frames the
-                  {{totalAssemblyTime}} is incremented.
+                  {{totalAssemblyTime}} is incremented. The average frame assembly time can be calculated by
+                  dividing the {{totalAssemblyTime}} with {{framesAssembledFromMultiplePackets}}.
                 </p>
               </dd>
               <dt>
@@ -1684,8 +1685,7 @@ enum RTCStatsType {
                   Only [= map/exist =]s for video. The sum of the time, in seconds, each video frame takes
                   from the time the first RTP packet is received (reception timestamp) and to the time
                   the last RTP packet of a frame is received. Only incremented for frames consisting of more
-                  than one RTP packet. The average frame assembly time can be calculated by dividing the
-                  {{totalAssemblyTime}} with {{framesAssembledFromMultiplePackets}}.
+                  than one RTP packet.
                 </p>
                 <p>
                   Given the complexities involved, the time of arrival or the reception timestamp is measured

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1689,9 +1689,9 @@ enum RTCStatsType {
                 <p>
                   Given the complexities involved, the time of arrival or the reception timestamp is measured
                   as close to the network layer as possible. This metric is not incremented for frames that
-                  are not decoded, i.e., {{framesDropped}}, {{partialFramesLost}} or frames that fail decoding for
-                  other reasons (if any). Only incremented for frames consisting of more than one RTP packet.
-                  The average frame assembly time can be calculated by dividing the {{totalAssemblyTime}} with
+                  are not decoded, i.e., {{framesDropped}} or frames that fail decoding for other reasons
+                  (if any). Only incremented for frames consisting of more than one RTP packet. The average
+                  frame assembly time can be calculated by dividing the {{totalAssemblyTime}} with
                   {{framesAssembledFromMultiplePackets}}.
                 </p>
               </dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1684,15 +1684,14 @@ enum RTCStatsType {
                   Only [= map/exist =]s for video. The sum of the time, in seconds, each video frame takes
                   from the time the first RTP packet is received (reception timestamp) and to the time
                   the last RTP packet of a frame is received. Only incremented for frames consisting of more
-                  than one RTP packet.
+                  than one RTP packet. The average frame assembly time can be calculated by dividing the
+                  {{totalAssemblyTime}} with {{framesAssembledFromMultiplePackets}}.
                 </p>
                 <p>
                   Given the complexities involved, the time of arrival or the reception timestamp is measured
                   as close to the network layer as possible. This metric is not incremented for frames that
                   are not decoded, i.e., {{framesDropped}} or frames that fail decoding for other reasons
-                  (if any). Only incremented for frames consisting of more than one RTP packet. The average
-                  frame assembly time can be calculated by dividing the {{totalAssemblyTime}} with
-                  {{framesAssembledFromMultiplePackets}}.
+                  (if any). Only incremented for frames consisting of more than one RTP packet.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1023,6 +1023,8 @@ enum RTCStatsType {
              DOMString            decoderImplementation;
              DOMString            playoutId;
              boolean              powerEfficientDecoder;
+             double               totalAssemblyTime;
+             unsigned long        framesAssembledFromMultiplePackets;
             };</pre>
           <section>
             <h2>
@@ -1660,6 +1662,33 @@ enum RTCStatsType {
                   configuration results in hardware acceleration, but the user
                   agent MAY take other information into account when deciding if
                   the configuration is considered power efficient.
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalAssemblyTime</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  Only [= map/exist =]s for video. The sum of the time, in seconds, each video frame takes
+                  from the time the first RTP packet is received (reception timestamp) and to the time
+                  the last RTP packet of a frame is received.
+                </p>
+                <p>
+                  Given the complexities involved, the time of arrival or the reception timestamp is measured as close to the network layer as possible.
+                  This metric is not incremented for frames that are not decoded, i.e., framesDropped, partialFramesLost or frames that fail decoding
+                  for other reasons (if any). Only incremented for frames consisting of more than one RTP packet. The average frame assembly time can
+                  be calculated by dividing the totalAssemblyTime with framesAssembledFromMultiplePackets.
+                </p>
+              </dd>
+              <dt>
+                <dfn>framesAssembledFromMultiplePackets</dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  Only [= map/exist =]s for video.  It represents the total number of frames correctly decoded for this RTP stream that consist of
+                  more than one RTP packet. For such frames the totalAssemblyTime is incremented.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
which allows measuring the average time to receive an inbound video frame.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/694.html" title="Last updated on Oct 4, 2022, 7:55 PM UTC (b9fbefd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/694/55d60dd...fippo:b9fbefd.html" title="Last updated on Oct 4, 2022, 7:55 PM UTC (b9fbefd)">Diff</a>