### PR TITLE
Remove fullscreen contexts hardware capability exposure

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -372,8 +372,8 @@ dictionary RTCStats {
         </h3>
         <p>
           To avoid passive fingerprinting, hardware capabilities should only be
-          exposed in capturing or fullscreen contexts. This is tested using the
-          algorithm below.
+          exposed in capturing contexts. This is tested using the algorithm
+          below.
         </p>
         <p>
           To <dfn data-lt="exposing hardware is allowed">check if hardware
@@ -383,14 +383,6 @@ dictionary RTCStats {
               <p>
                 If the <a href="https://w3c.github.io/mediacapture-main/#context-capturing-state">
                 context capturing state</a> is true, return true.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the current <code>Document</code>'s
-                <a href="https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement">
-                fullscreenElement</a> getter returns a non-null value, return
-                true.
               </p>
             </li>
             <li>


### PR DESCRIPTION
Fixes #712

A fullscreen element is not as trustworthy enough as a website whose able to fullscreen may just have a <video> element and does not require that WebRTC is used for purpose. This makes gUM access as the sole requirement for exposing hardware capabilities. This is a PR implementing the suggestions of #712.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eshrubs/webrtc-stats/pull/713.html" title="Last updated on Dec 1, 2022, 4:38 PM UTC (468be14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/713/52dc140...eshrubs:468be14.html" title="Last updated on Dec 1, 2022, 4:38 PM UTC (468be14)">Diff</a>