### PR TITLE
Change RTCAudioPlayoutStats::totalSamplesCount to unsigned long long

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2762,11 +2762,11 @@ enum RTCStatsType {
         </p>
         <div>
           <pre class="idl">dictionary RTCAudioPlayoutStats : RTCStats {
-             double        synthesizedSamplesDuration;
-             unsigned long synthesizedSamplesEvents;
-             double        totalSamplesDuration;
-             double        totalPlayoutDelay;
-             double        totalSamplesCount;
+             double             synthesizedSamplesDuration;
+             unsigned long      synthesizedSamplesEvents;
+             double             totalSamplesDuration;
+             double             totalPlayoutDelay;
+             unsigned long long totalSamplesCount;
 };</pre>
           <section>
             <h2>
@@ -2837,7 +2837,7 @@ enum RTCStatsType {
               </dd>
               <dt>
                 <dfn>totalSamplesCount</dfn> of type <span class=
-                "idlMemberType">double</span>
+                "idlMemberType">unsigned long long</span>
               </dt>
               <dd>
                 <p>


### PR DESCRIPTION
Fixes #719


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Hernqvist/webrtc-stats/pull/720.html" title="Last updated on Dec 14, 2022, 10:26 AM UTC (4b1ba78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/720/d0dc3aa...Hernqvist:4b1ba78.html" title="Last updated on Dec 14, 2022, 10:26 AM UTC (4b1ba78)">Diff</a>