### PR TITLE
Don't export the informative RTCStats reproduction

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -147,7 +147,8 @@
       </p>
       <p>
         The stats API is defined in [[!WEBRTC]]. It is defined to return a collection of [= stats object =]s, each of which is a dictionary inheriting directly or indirectly from the
-        {{RTCStats}} dictionary. This API is normatively defined in [[!WEBRTC]], but is
+        <dfn class="informative" data-noexport>RTCStats</dfn> dictionary.
+        This API is normatively defined in [[!WEBRTC]], but is
         reproduced here for ease of reference.
       </p>
       <pre class="idl informative">


### PR DESCRIPTION
The `RTCStats` dictionary is normatively defined in WebRTC and reproduced in WebRTC Stats for ease of reference only. The IDL block is correctly flagged as informative, but ReSpec still exports the IDL term, meaning that `{{RTCStats}}` can either be interpreted to mean:
1. a normative reference to the `RTCStats` dictionary defined in WebRTC
2. an informative reference to the `RTCStats` dictionary reproductionin WebRTC Stats.

The informative reproduction should not be exported. This update tells ReSpec not to export `RTCStats`. Note that there is no way (at least none that I'm aware of) to do that directly within the IDL block, so this moves the definition to the prose that precedes the IDL block.

Via https://github.com/w3c/webref/issues/306#issuecomment-1355169213


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webrtc-stats/pull/721.html" title="Last updated on Dec 19, 2022, 2:12 PM UTC (2a57f02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/721/d9121b4...tidoust:2a57f02.html" title="Last updated on Dec 19, 2022, 2:12 PM UTC (2a57f02)">Diff</a>