### PR TITLE
Add RTCInboundRtpStreamStats:decoderFallback

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1032,6 +1032,7 @@ enum RTCStatsType {
              boolean              powerEfficientDecoder;
              unsigned long        framesAssembledFromMultiplePackets;
              double               totalAssemblyTime;
+             boolean              decoderFallback;
             };</pre>
           <section>
             <h2>
@@ -1710,6 +1711,16 @@ enum RTCStatsType {
                   as close to the network layer as possible. This metric is not incremented for frames that
                   are not decoded, i.e., {{framesDropped}} or frames that fail decoding for other reasons
                   (if any). Only incremented for frames consisting of more than one RTP packet.
+                </p>
+              </dd>
+              <dt>
+                <dfn>decoderFallback</dfn> of type <span class=
+                "idlMemberType">boolean</span>
+              </dt>
+              <dd>
+                <p>
+                  Only [= map/exist =]s for video. It indicates that the current WebRTC session is fallbacked
+		  to the Software Decoder. When the session has started with Hardware Decoder.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-stats/issues/724, https://github.com/w3c/webrtc-stats/issues/730


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xingri/webrtc-stats/pull/725.html" title="Last updated on Mar 10, 2023, 7:08 AM UTC (1efea03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/725/3057aa7...xingri:1efea03.html" title="Last updated on Mar 10, 2023, 7:08 AM UTC (1efea03)">Diff</a>