### PR TITLE
Fix stats object reference in example code

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -4457,8 +4457,8 @@ function processStats() {
         let base = baselineReport.get(now.id);
 
         if (base) {
-            remoteNow = currentReport[now.remoteId];
-            remoteBase = baselineReport[base.remoteId];
+            remoteNow = currentReport.get(now.remoteId);
+            remoteBase = baselineReport.get(base.remoteId);
 
             var packetsSent = now.packetsSent - base.packetsSent;
             var packetsReceived = remoteNow.packetsReceived - remoteBase.packetsReceived;


### PR DESCRIPTION
Fixes a minor issue with example code: [RTCStatsReport is a map,](https://www.w3.org/TR/webrtc/#dom-rtcstatsreport) so property accessors shouldn't be expected. The `.get()` method should be used instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/redoPop/webrtc-stats/pull/726.html" title="Last updated on Jan 12, 2023, 6:10 PM UTC (94f2339)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/726/d65d1b0...redoPop:94f2339.html" title="Last updated on Jan 12, 2023, 6:10 PM UTC (94f2339)">Diff</a>