### PR TITLE
Expose powerEfficientEncoder/Decoder if MediaCapabilities allows it

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -373,17 +373,27 @@ dictionary RTCStats {
         </h3>
         <p>
           To avoid passive fingerprinting, hardware capabilities should only be
-          exposed in capturing contexts. This is tested using the algorithm
-          below.
+          exposed in capturing contexts or contexts where Media Capabilities
+          permit hardware exposure. This is tested using the algorithm below.
         </p>
         <p>
           To <dfn data-lt="exposing hardware is allowed">check if hardware
-          exposure is allowed</dfn>, run the following steps:
+          exposure is allowed</dfn>, optionally taking a
+          <var>codec configuration</var> as an argument, run the following
+          steps:
           <ol>
             <li>
               <p>
                 If the <a href="https://w3c.github.io/mediacapture-main/#context-capturing-state">
                 context capturing state</a> is true, return true.
+              </p>
+            </li>
+            <li>
+              <p>
+                If a <var>codec configuration</var> was passed to this
+                algorithm and <a href="https://w3c.github.io/media-capabilities/#dom-mediacapabilitiesinfo-powerefficient">
+                Media Capabilities' powerEfficient</a> is allowed to be exposed
+                for this configuration and context, return true.
               </p>
             </li>
             <li>
@@ -1670,7 +1680,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p class="fingerprint">
-                  Only defined when [= exposing hardware is allowed =].
+                  Only defined when [= exposing hardware is allowed =] with
+                  <var>codec configuration</var> being set to the current codec
+                  configuration.
                 </p>
                 <p>
                   Whether the decoder currently used is considered power
@@ -2226,7 +2238,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p class="fingerprint">
-                  Only defined when [= exposing hardware is allowed =].
+                  Only defined when [= exposing hardware is allowed =] with
+                  <var>codec configuration</var> being set to the current codec
+                  configuration.
                 </p>
                 <p>
                   Whether the encoder currently used is considered power


### PR DESCRIPTION
Fixes #730.

This exposes powerEfficientEncoder and powerEfficientDecoder (but not encoderImplementation or decoderImplementation) in contexts that are not capturing but where MediaCapabilities' powerEfficient already allows exposure.

This should not significantly increase fingerprinting surface beyond what MediaCapabilities is already doing and if MC becomes more restrictive than so would getStats.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/732.html" title="Last updated on Feb 7, 2023, 3:15 PM UTC (cb5197c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/732/2ada0c9...henbos:cb5197c.html" title="Last updated on Feb 7, 2023, 3:15 PM UTC (cb5197c)">Diff</a>