### PR TITLE
mark totalInterFrameDelay and totalSquaredInterFrameDelay as video-only

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1205,7 +1205,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only [= map/exist =]s for video.
+                  Does not [= map/exist =] for audio.
                   Sum of the squared interframe delays in seconds between consecutively rendered frames,
                   recorded just after a frame has been rendered. See {{totalInterFrameDelay}} for
                   details on how to calculate the interframe delay variance.

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1190,7 +1190,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Only [= map/exist =]s for video.
+                  Does not [= map/exist =] for audio.
                   Sum of the interframe delays in seconds between consecutively rendered frames,
                   recorded just after a frame has been rendered. The interframe delay variance be
                   calculated from {{totalInterFrameDelay}}, {{totalSquaredInterFrameDelay}},

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1190,6 +1190,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
+                  Only [= map/exist =]s for video.
                   Sum of the interframe delays in seconds between consecutively rendered frames,
                   recorded just after a frame has been rendered. The interframe delay variance be
                   calculated from {{totalInterFrameDelay}}, {{totalSquaredInterFrameDelay}},
@@ -1204,6 +1205,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
+                  Only [= map/exist =]s for video.
                   Sum of the squared interframe delays in seconds between consecutively rendered frames,
                   recorded just after a frame has been rendered. See {{totalInterFrameDelay}} for
                   details on how to calculate the interframe delay variance.


### PR DESCRIPTION
fixes #656


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/733.html" title="Last updated on Mar 7, 2023, 2:28 PM UTC (1db3085)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/733/2ada0c9...fippo:1db3085.html" title="Last updated on Mar 7, 2023, 2:28 PM UTC (1db3085)">Diff</a>