### PR TITLE
editorial: fix decoderImplementation idl reference

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3926,7 +3926,7 @@ enum RTCStatsType {
           </dt>
           <dd>
             <p>
-              This was moved to {{RTCInboundRtpStreamStats}}.{{RTCInboundRtpStreamStats}}/decoderImplementation}}
+              This was moved to {{RTCInboundRtpStreamStats}}.{{RTCInboundRtpStreamStats/decoderImplementation}}
               and {{RTCOutboundRtpStreamStats}}.{{RTCOutboundRtpStreamStats/encoderImplementation}} in August
               2019.
             </p>


### PR DESCRIPTION
which showed up as
   RTCInboundRtpStreamStats/decoderImplementation}}
due to extra closing }}


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/734.html" title="Last updated on Feb 16, 2023, 5:37 PM UTC (61efd4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/734/2ada0c9...fippo:61efd4a.html" title="Last updated on Feb 16, 2023, 5:37 PM UTC (61efd4a)">Diff</a>