### PR TITLE
specifiy inbound-rtp RTX statistics

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1718,9 +1718,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The total number of RTX packets that were received for this <a>SSRC</a>. This is a
+                  The total number of retransmitted packets that were received for this <a>SSRC</a>. This is a
                   subset of {{RTCReceivedRtpStreamStats/packetsReceived}}. If RTX is not negotiated,
-                  retransmitted packets can not be identified and this count is not defined.
+                  retransmitted packets can not be identified and this member does not [= map/exist =].
                 </p>
               </dd>
               <dt>
@@ -1729,9 +1729,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The total number of RTX bytes that were received for this <a>SSRC</a>, only including
+                  The total number of retransmitted bytes that were received for this <a>SSRC</a>, only including
                   payload bytes. This is a subset of {{RTCReceivedRtpStreamStats/bytesReceived}}. If RTX is not
-                  negotiated, retransmitted pacakets can not be identified and this count is not defined.
+                  negotiated, retransmitted pacakets can not be identified and this member does not [= map/exist =].
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1032,6 +1032,8 @@ enum RTCStatsType {
              boolean              powerEfficientDecoder;
              unsigned long        framesAssembledFromMultiplePackets;
              double               totalAssemblyTime;
+             unsigned long long   retransmittedPacketsReceived;
+             unsigned long long   retransmittedBytesReceived;
             };</pre>
           <section>
             <h2>
@@ -1708,6 +1710,28 @@ enum RTCStatsType {
                   as close to the network layer as possible. This metric is not incremented for frames that
                   are not decoded, i.e., {{framesDropped}} or frames that fail decoding for other reasons
                   (if any). Only incremented for frames consisting of more than one RTP packet.
+                </p>
+              </dd>
+              <dt>
+                <dfn>retransmittedPacketsReceived</dfn> of type <span class=
+                "idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  The total number of RTX packets that were received for this <a>SSRC</a>. This is a
+                  subset of {{RTCReceivedRtpStreamStats/packetsReceived}}. If RTX is not negotiated,
+                  retransmitted packets can not be identified and this count is not defined.
+                </p>
+              </dd>
+              <dt>
+                <dfn>retransmittedBytesReceived</dfn> of type <span class=
+                "idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  The total number of RTX bytes that were received for this <a>SSRC</a>, only including
+                  payload bytes. This is a subset of {{RTCReceivedRtpStreamStats/bytesReceived}}. If RTX is not
+                  negotiated, retransmitted pacakets can not be identified and this count is not defined.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1730,8 +1730,8 @@ enum RTCStatsType {
               <dd>
                 <p>
                   The total number of retransmitted bytes that were received for this <a>SSRC</a>, only including
-                  payload bytes. This is a subset of {{RTCReceivedRtpStreamStats/bytesReceived}}. If RTX is not
-                  negotiated, retransmitted pacakets can not be identified and this member does not [= map/exist =].
+                  payload bytes. This is a subset of {{RTCInboundRtpStreamStats/bytesReceived}}. If RTX is not
+                  negotiated, retransmitted packets can not be identified and this member does not [= map/exist =].
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
* retransmittedBytesReceived
* retransmittedPacketsReceived
similar to the outbound-rtp ones. However, they are only defined
when RTX is negotiated as it is impossible to determine whether
a received packet is a retransmission otherwise.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/735.html" title="Last updated on Mar 7, 2023, 4:00 PM UTC (97daa37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/735/95726c2...fippo:97daa37.html" title="Last updated on Mar 7, 2023, 4:00 PM UTC (97daa37)">Diff</a>