### PR TITLE
Fix wrong html tag for mediaSourceId description

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1895,7 +1895,7 @@ enum RTCStatsType {
                   value, otherwise this member is not present.
                 </p>
               </dd>
-              <dd>
+              <dt>
                 <dfn>mediaSourceId</dfn> of type <span class=
                 "idlMemberType">DOMString</span>
               </dt>


### PR DESCRIPTION
which was causing a weird indent:
![image](https://user-images.githubusercontent.com/289731/222674632-1439652d-270c-4ebc-b8c3-4abc06e5ecae.png)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/738.html" title="Last updated on Mar 3, 2023, 8:48 AM UTC (44197d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/738/95726c2...fippo:44197d2.html" title="Last updated on Mar 3, 2023, 8:48 AM UTC (44197d2)">Diff</a>