### PR TITLE
Clarify when the candidate pair bandwidth estimation(s) exists

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3632,9 +3632,9 @@ enum RTCStatsType {
                 </p>
                 <p>
                   Only [= map/exist =]s when the underlying congestion control calculated either a
-                  send-side bandwidth estimation using mechanisms such as
+                  send-side bandwidth estimation, for example using mechanisms such as
                   <a href="https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01">TWCC</a>
-                  or received a receive-side estimation via RTCP as described in
+                  or received a receive-side estimation via RTCP, for example the one described in
                   <a href="https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03">REMB</a>.
                   Does not [= map/exist =] for candidate pairs that were never used
                   for sending packets that were taken into account for bandwidth estimation or
@@ -3658,7 +3658,7 @@ enum RTCStatsType {
                   might be higher.
                 </p>
                 <p>
-                  Only [= map/exist =]s when a receive-side bandwidth estimation such as
+                  Only [= map/exist =]s when a receive-side bandwidth estimation, for example
                   <a href="https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03">REMB</a>
                   was calculated. Does not [= map/exist =] for candidate pairs that were never used
                   for receiving packets that were taken into account for bandwidth estimation or

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3631,7 +3631,11 @@ enum RTCStatsType {
                   be higher.
                 </p>
                 <p>
-                  Only [= map/exist =] when a sender-side bandwidth estimate was calculcated.
+                  Only [= map/exist =]s when the underlying congestion control calculated either a
+                  send-side bandwidth estimation using mechanisms such as
+                  <a href="https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01">TWCC</a>
+                  or received a receive-side estimation via RTCP as described in
+                  <a href="https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03">REMB</a>.
                   Does not [= map/exist =] for candidate pairs that were never used
                   for sending packets that were taken into account for bandwidth estimation or
                   candidate pairs that have have been used previously but are not currently in use.
@@ -3654,9 +3658,10 @@ enum RTCStatsType {
                   might be higher.
                 </p>
                 <p>
-                  Only [= map/exist =] when a receiver-side bandwidth estimate was calculcated.
-                  Does not [= map/exist =] for candidate pairs that were never used for receiving
-                  packets that were taken into account for bandwidth estimation or
+                  Only [= map/exist =]s when a receive-side bandwidth estimation such as
+                  <a href="https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03">REMB</a>
+                  was calculated. Does not [= map/exist =] for candidate pairs that were never used
+                  for receiving packets that were taken into account for bandwidth estimation or
                   candidate pairs that have have been used previously but are not currently in use.
                 </p>
               </dd>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3633,7 +3633,7 @@ enum RTCStatsType {
                 <p>
                   Only [= map/exist =]s when the underlying congestion control calculated either a
                   send-side bandwidth estimation, for example using mechanisms such as
-                  <a href="https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01">TWCC</a>
+                  <a href="https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01">TWCC</a>,
                   or received a receive-side estimation via RTCP, for example the one described in
                   <a href="https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03">REMB</a>.
                   Does not [= map/exist =] for candidate pairs that were never used


### PR DESCRIPTION
fixes #740


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/743.html" title="Last updated on May 11, 2023, 2:26 PM UTC (50e3b9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/743/063ffa4...fippo:50e3b9a.html" title="Last updated on May 11, 2023, 2:26 PM UTC (50e3b9a)">Diff</a>