### PR TITLE
Make RTCRtpSentRtpStreamStats.packetsSent unsigned long long

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1807,7 +1807,7 @@ enum RTCStatsType {
         </h3>
         <div>
           <pre class="idl">dictionary RTCSentRtpStreamStats : RTCRtpStreamStats {
-             unsigned long      packetsSent;
+             unsigned long long packetsSent;
              unsigned long long bytesSent;
 };</pre>
           <section>


### PR DESCRIPTION
for consistency with the description and other places where packets are counted.
Note that in RTCP receiver reports this is still a 32 bit field.

(this is widening the field width so *should* be safe)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/744.html" title="Last updated on Mar 7, 2023, 4:50 PM UTC (a841960)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/744/063ffa4...fippo:a841960.html" title="Last updated on Mar 7, 2023, 4:50 PM UTC (a841960)">Diff</a>