### PR TITLE
Clarify that metrics are omitted when their value is not yet determined

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -56,7 +56,7 @@
       <p>
         This specification does not define what objects a conforming implementation should
         generate. Specifications that refer to this specification have the need to specify
-        conformance. They should put in their document text that could like this (EXAMPLE ONLY):
+        conformance. They should put in their document text like this (EXAMPLE ONLY):
       </p>
       <ul>
         <li>An implementation MUST support generating statistics for the type
@@ -89,8 +89,12 @@
       <p>
         The term <dfn><a href="https://datatracker.ietf.org/doc/html/rfc7656#section-2.1.10">RTP stream</a></dfn> is defined in [[RFC7656]].
       </p>
-      <p>The terms <dfn data-lt="SSRC"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-3">Synchronization Source</a></dfn> (SSRC), <dfn data-lt="Sender Report|SR|RTCP SR"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1">RTCP Sender Report</a></dfn>, <dfn data-lt="Receiver Report|RR|RTCP RR"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.2">RTCP Receiver Report</a></dfn> are defined in [[RFC3550]].</p>
-      <p>The term <dfn data-lt="Extended Report|XR"><a href="https://datatracker.ietf.org/doc/html/rfc3611">RTCP Extended Report</a></dfn> is defined in [[RFC3611]].</p>
+      <p>
+        The terms <dfn data-lt="SSRC"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-3">Synchronization Source</a></dfn> (SSRC),
+        <dfn data-lt="Sender Report|SR|RTCP SR"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.1">RTCP Sender Report</a></dfn> (SR),
+        <dfn data-lt="Receiver Report|RR|RTCP RR"><a href="https://datatracker.ietf.org/doc/html/rfc3550#section-6.4.2">RTCP Receiver Report</a></dfn> (RR) are defined in [[RFC3550]].
+      </p>
+      <p>The term <dfn data-lt="Extended Report|XR"><a href="https://datatracker.ietf.org/doc/html/rfc3611">RTCP Extended Report</a></dfn> (XR) is defined in [[RFC3611]].</p>
       <p>An <dfn>audio sample</dfn> refers to having a sample in any channel of an audio track - if multiple audio channels are used, metrics based on samples do not increment at a higher rate, simultaneously having samples in multiple channels counts as a single sample.</p>
     </section>
     <section>
@@ -193,9 +197,8 @@ dictionary RTCStats {
         </p>
         <p>
           Names ending in <code>Id</code> (such as {{RTCRtpStreamStats/transportId}}) are always a [= stats object reference =];
-          <!-- TODO: Ids name are only obsolete now? -->
-          names ending in <code>Ids</code> (such as {{RTCMediaStreamStats/trackIds}}) are always of type sequence&lt;DOMString&gt;,
-          where each {{DOMString}} is a [= stats object reference =].
+          names ending in <code>Ids</code> (such as the obsolete {{RTCMediaStreamStats/trackIds}}) are always of type
+          sequence&lt;{{DOMString}}&gt;, where each {{DOMString}} is a [= stats object reference =].
         </p>
         <p>
           If the natural name for a stats value would end in <code>id</code> (such as when the stats value is
@@ -232,12 +235,12 @@ dictionary RTCStats {
           <li>When a feature is not implemented on the platform, omit the dictionary member that is
           tracking usage of the feature.
           </li>
-          <li>When a feature is not applicable to an instance of an object (for example {{RTCInboundRtpStreamStats/audioLevel}}
-          on a video stream), omit the dictionary member. Do NOT report a count of zero, -1 or
-          "empty string".
+          <li>When a feature is not applicable to an instance of an object (for example{{RTCInboundRtpStreamStats/audioLevel}}
+          on a video stream), it shall not [= map/exist =].
           </li>
-          <li>When a counted feature hasn't been used yet, but may happen in the future, report a
-          count of zero.
+          <li>When an instantaneous feature has not yet been sampled, it shall not [= map/exist =].</li>
+          <li>When a cumulative feature hasn't been sampled yet, but is likely to increment in the future, report a
+          count of zero. This allows subtraction of such features without additional checks for existence.
           </li>
         </ul>
       </section>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -235,7 +235,7 @@ dictionary RTCStats {
           <li>When a feature is not implemented on the platform, omit the dictionary member that is
           tracking usage of the feature.
           </li>
-          <li>When a feature is not applicable to an instance of an object (for example{{RTCInboundRtpStreamStats/audioLevel}}
+          <li>When a feature is not applicable to an instance of an object (for example {{RTCInboundRtpStreamStats/audioLevel}}
           on a video stream), it shall not [= map/exist =]. Do NOT report a count of zero, -1 or "empty string".
           </li>
           <li>When a feature is an instantaneous measure and it has not yet been

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -240,7 +240,8 @@ dictionary RTCStats {
           </li>
           <li>When a features is an instantaneous measure and it has not yet been
           sampled, it shall not [= map/exist =].</li>
-          <li>When a cumulative feature hasn't been sampled yet, but is likely to increment in the future, report a
+          <li>When a feature is a cumulative measure and it has not been sampled yet,
+          but is likely to increment in the future, report a
           count of zero. This allows subtraction of such features without additional checks for existence.
           </li>
         </ul>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -238,7 +238,8 @@ dictionary RTCStats {
           <li>When a feature is not applicable to an instance of an object (for example{{RTCInboundRtpStreamStats/audioLevel}}
           on a video stream), it shall not [= map/exist =]. Do NOT report a count of zero, -1 or "empty string".
           </li>
-          <li>When an instantaneous feature has not yet been sampled, it shall not [= map/exist =].</li>
+          <li>When a features is an instantaneous measure and it has not yet been
+          sampled, it shall not [= map/exist =].</li>
           <li>When a cumulative feature hasn't been sampled yet, but is likely to increment in the future, report a
           count of zero. This allows subtraction of such features without additional checks for existence.
           </li>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -236,7 +236,7 @@ dictionary RTCStats {
           tracking usage of the feature.
           </li>
           <li>When a feature is not applicable to an instance of an object (for example{{RTCInboundRtpStreamStats/audioLevel}}
-          on a video stream), it shall not [= map/exist =].
+          on a video stream), it shall not [= map/exist =]. Do NOT report a count of zero, -1 or "empty string".
           </li>
           <li>When an instantaneous feature has not yet been sampled, it shall not [= map/exist =].</li>
           <li>When a cumulative feature hasn't been sampled yet, but is likely to increment in the future, report a

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -238,7 +238,7 @@ dictionary RTCStats {
           <li>When a feature is not applicable to an instance of an object (for example{{RTCInboundRtpStreamStats/audioLevel}}
           on a video stream), it shall not [= map/exist =]. Do NOT report a count of zero, -1 or "empty string".
           </li>
-          <li>When a features is an instantaneous measure and it has not yet been
+          <li>When a feature is an instantaneous measure and it has not yet been
           sampled, it shall not [= map/exist =].</li>
           <li>When a feature is a cumulative measure and it has not been sampled yet,
           but is likely to increment in the future, report a


### PR DESCRIPTION
fixes #736 with some editorial drive-bys.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/745.html" title="Last updated on Mar 21, 2023, 6:40 PM UTC (b697781)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/745/063ffa4...fippo:b697781.html" title="Last updated on Mar 21, 2023, 6:40 PM UTC (b697781)">Diff</a>