### PR TITLE
Specify fecBytesReceived

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -466,6 +466,13 @@ enum RTCStatsType {
               and {{RTCInboundRtpStreamStats/retransmittedBytesReceived}} counters of the relevant
               {{RTCInboundRtpStreamStats}} objects.
             </p>
+            <p>
+              FEC streams do not show up as separate
+              {{RTCInboundRtpStreamStats}} objects but affect the {{RTCReceivedRtpStreamStats/packetsReceived}},
+              {{RTCInboundRtpStreamStats/bytesReceived}}, {{RTCInboundRtpStreamStats/fecPacketsReceived}}
+              and {{RTCInboundRtpStreamStats/fecBytesReceived}} counters of the relevant
+              {{RTCInboundRtpStreamStats}} objects.
+            </p>
           </dd>
           <dt>
             <dfn>outbound-rtp</dfn>
@@ -1283,7 +1290,9 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Total number of RTP FEC bytes received for this <a>SSRC</a>, only including payload bytes.
-                  This is a subset of {{RTCInboundRtpStreamStats/bytesReceived}}.
+                  This is a subset of {{RTCInboundRtpStreamStats/bytesReceived}}. If a FEC mechanism that
+                  uses a different {{RTCRtpStreamStats/ssrc}} was negotiated, FEC packets are sent over a
+                  separate ssrc but is still accounted for here.
                 </p>
               </dd>
               <dt>
@@ -1292,9 +1301,11 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Total number of RTP FEC packets received for this <a>SSRC</a>. This counter can also be
-                  incremented when receiving FEC packets in-band with media packets (e.g., with
-                  Opus).
+                  Total number of RTP FEC packets received for this <a>SSRC</a>. If a FEC mechanism that
+                  uses a different {{RTCRtpStreamStats/ssrc}} was negotiated, FEC packets are sent over a
+                  separate ssrc but is still accounted for here.
+                  This counter can also be incremented when receiving FEC packets in-band with media packets
+                  (e.g., with Opus).
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -984,6 +984,7 @@ enum RTCStatsType {
              DOMHighResTimeStamp  lastPacketReceivedTimestamp;
              unsigned long long   headerBytesReceived;
              unsigned long long   packetsDiscarded;
+             unsigned long long   fecBytesReceived;
              unsigned long long   fecPacketsReceived;
              unsigned long long   fecPacketsDiscarded;
              unsigned long long   bytesReceived;
@@ -1273,6 +1274,16 @@ enum RTCStatsType {
                   or early-arrival, i.e., these packets are not played out. RTP packets discarded
                   due to packet duplication are not reported in this metric [[XRBLOCK-STATS]].
                   Calculated as defined in [[!RFC7002]] section 3.2 and Appendix A.a.
+                </p>
+              </dd>
+              <dt>
+                <dfn>fecBytesReceived</dfn> of type <span class=
+                "idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  Total number of RTP FEC bytes received for this <a>SSRC</a>, only including payload bytes.
+                  This is a subset of {{RTCInboundRtpStreamStats/bytesReceived}}.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
similar to how retransmittedBytesReceived is defined.

Fixes #751

For audio "FEC" usually means opus inband FEC (also known as low-bitrate redundacy, LBRR). This is typically sent together with an actual opus primary frame as secondary payload. Yet we count those as fecPacketsReceived but you can't add or subtract this from the RTP packets received. Since this is part of the same RTP payload counting separate fecHeaderBytesReceived does not make sense (we do not count RTP headers separately for RTX either btw)

For video we have two FEC mechanisms, ULPFEC and FLEXFEC.
* FlexFEC uses a separate SSRC so is similar to RTX when it comes to counting things. I do not think that implementations currently properly account for flexfec bytes but the rationale that it should be a subset of bytesReceived holds.
* ULPFEC uses the same SSRC but a different payload type. It should be accounted for if one counts all packets with a particular SSRC already


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/762.html" title="Last updated on Jun 14, 2023, 1:00 PM UTC (b42b284)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/762/6e9db1c...fippo:b42b284.html" title="Last updated on Jun 14, 2023, 1:00 PM UTC (b42b284)">Diff</a>