### PR TITLE
Delete 'retiring stats objects' section.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -340,27 +340,6 @@ dictionary RTCStats {
           updates happen.
         </p>
       </section>
-      <section>
-        <h3>
-          Retiring stats objects
-        </h3>
-        <p>
-          At times, it makes sense to retire the definition for a stats object or a stats value.
-          When this happens, it is not advisable to simply delete it from the spec, since there may
-          be implementations out there that use it, and it is important that the name is reserved
-          from re-use for another, incompatible definition.
-        </p>
-        <p>
-          Therefore, retired stats objects are moved to a separate section in this document.
-          Retired stats objects are moved there in their entirety; retired stats values are moved
-          to a "partial dictionary".
-        </p>
-        <p>
-          If there is no evidence that the retired object definition has ever been used (such as an
-          object that is added to the spec and renamed, redefined or removed prior to
-          implementation), the editors can decide to just remove the object from the spec.
-        </p>
-      </section>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
Fixes #729


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/763.html" title="Last updated on Jun 22, 2023, 2:56 PM UTC (54ddf23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/763/611d409...henbos:54ddf23.html" title="Last updated on Jun 22, 2023, 2:56 PM UTC (54ddf23)">Diff</a>