### PR TITLE
add rtxSsrc to inbound-rtp and outbound-rtp stats and fecSsrc to inbound-rtp

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1022,6 +1022,7 @@ enum RTCStatsType {
              unsigned long long   retransmittedPacketsReceived;
              unsigned long long   retransmittedBytesReceived;
              unsigned long        rtxSsrc;
+             unsigned long        fecSsrc;
             };</pre>
           <section>
             <h2>
@@ -1748,6 +1749,17 @@ enum RTCStatsType {
                   If RTX is negotiated for retransmissions on a separate <a>RTP stream</a>, this is the SSRC
                   of the RTX stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
                   If RTX is not negotiated, this value is not present.
+                </p>
+              </dd>
+              <dt>
+                <dfn>fecSsrc</dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  If a FEC mechanism that uses a separate <a>RTP stream</a>, this is the SSRC
+                  of the FEC stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
+                  If FEC is not negotiated or uses the same <a>RTP stream</a>, this value is not present.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1757,7 +1757,7 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  If a FEC mechanism that uses a separate <a>RTP stream</a>, this is the SSRC
+                  If a FEC mechanism that uses a separate <a>RTP stream</a> is negotiated, this is the SSRC
                   of the FEC stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
                   If FEC is not negotiated or uses the same <a>RTP stream</a>, this value is not present.
                 </p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1021,6 +1021,7 @@ enum RTCStatsType {
              double               totalAssemblyTime;
              unsigned long long   retransmittedPacketsReceived;
              unsigned long long   retransmittedBytesReceived;
+             unsigned long        rtxSsrc;
             };</pre>
           <section>
             <h2>
@@ -1738,6 +1739,17 @@ enum RTCStatsType {
                   negotiated, retransmitted packets can not be identified and this member does not [= map/exist =].
                 </p>
               </dd>
+              <dt>
+                <dfn>rtxSsrc</dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  If RTX is negotiated for retransmissions on a separate <a>RTP stream</a>, this is the SSRC
+                  of the RTX stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
+                  If RTX is not negotiated, this value is not present.
+                </p>
+              </dd>
             </dl>
           </section>
         </div>
@@ -1884,6 +1896,7 @@ enum RTCStatsType {
              unsigned long long   headerBytesSent;
              unsigned long long   retransmittedPacketsSent;
              unsigned long long   retransmittedBytesSent;
+             unsigned long        rtxSsrc;
              double               targetBitrate;
              unsigned long long   totalEncodedBytesTarget;
              unsigned long        frameWidth;
@@ -1991,6 +2004,17 @@ enum RTCStatsType {
                   negotiated, retransmitted bytes are sent over this {{RTCRtpStreamStats/ssrc}}. If RTX
                   was negotiated, retransmitted bytes are sent over a separate ssrc but is still
                   accounted for here.
+                </p>
+              </dd>
+              <dt>
+                <dfn>rtxSsrc</dfn> of type <span class=
+                "idlMemberType">unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  If RTX is negotiated for retransmissions on a separate <a>RTP stream</a>, this is the SSRC
+                  of the RTX stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
+                  If RTX is not negotiated, this value is not present.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
For RTX this was previously defined in
  https://w3c.github.io/webrtc-provisional-stats/#dom-rtcoutboundrtpstreamstats-rtxssrc
(only for outbound)

For FEC it is only defined for inbound-rtp due to the lack of a sender-side implementation of flexfec (this does not apply to ulpfec which uses the same SSRC)

fixes #751 (once again)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/765.html" title="Last updated on Jul 24, 2023, 5:52 PM UTC (16e4480)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/765/611d409...fippo:16e4480.html" title="Last updated on Jul 24, 2023, 5:52 PM UTC (16e4480)">Diff</a>