### PR TITLE
Remove duplicate RTCInboundRtpStreamStats `kind`

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -970,7 +970,6 @@ enum RTCStatsType {
         <div>
           <pre class="idl">dictionary RTCInboundRtpStreamStats : RTCReceivedRtpStreamStats {
              required DOMString   trackIdentifier;
-             required DOMString   kind;
              DOMString            mid;
              DOMString            remoteId;
              unsigned long        framesDecoded;


### PR DESCRIPTION
which is already defined by inheritance

Fixes #690


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/766.html" title="Last updated on Jul 25, 2023, 9:59 AM UTC (266944d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/766/f6a0c81...fippo:266944d.html" title="Last updated on Jul 25, 2023, 9:59 AM UTC (266944d)">Diff</a>