### PR TITLE
Remove duplicate definition of RTCInboundRtpStreamStats kind

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1018,15 +1018,6 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn>kind</dfn> of type <span class="idlMemberType">DOMString</span>
-              </dt>
-              <dd>
-                <p>
-                  The value of the {{MediaStreamTrack}}'s <code class=gum>kind</code> attribute.
-                  This is either <code class=gum>"audio"</code> or <code class=gum>"video"</code>.
-                </p>
-              </dd>
-              <dt>
                 <dfn>mid</dfn> of type <span class=
                 "idlMemberType">DOMString</span>
               </dt>


### PR DESCRIPTION
in addition to the IDL. Follow-up to #766

Fixes #690

(thanks @vr000m for catching it)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/767.html" title="Last updated on Aug 4, 2023, 6:53 AM UTC (001b1b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/767/bb3930d...fippo:001b1b0.html" title="Last updated on Aug 4, 2023, 6:53 AM UTC (001b1b0)">Diff</a>