### PR TITLE
Replace 'is not present' with 'MUST NOT be [= map/exist | present =]'

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1024,8 +1024,9 @@ enum RTCStatsType {
               <dd>
                 <p>
                   If the {{RTCRtpTransceiver}} owning this stream has a
-                  {{RTCRtpTransceiver/mid}} value that is not null, this is that
-                  value, otherwise this member is not present.
+                  {{RTCRtpTransceiver/mid}} value that is not <code>null</code>,
+                  this is that value, otherwise this member MUST NOT be
+                  [= map/exist | present =].
                 </p>
               </dd>
               <dt>
@@ -1726,7 +1727,7 @@ enum RTCStatsType {
                 <p>
                   If RTX is negotiated for retransmissions on a separate <a>RTP stream</a>, this is the SSRC
                   of the RTX stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
-                  If RTX is not negotiated, this value is not present.
+                  If RTX is not negotiated, this value MUST NOT be [= map/exist | present =].
                 </p>
               </dd>
               <dt>
@@ -1737,7 +1738,8 @@ enum RTCStatsType {
                 <p>
                   If a FEC mechanism that uses a separate <a>RTP stream</a> is negotiated, this is the SSRC
                   of the FEC stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
-                  If FEC is not negotiated or uses the same <a>RTP stream</a>, this value is not present.
+                  If FEC is not negotiated or uses the same <a>RTP stream</a>, this value MUST NOT be
+                  [= map/exist | present =].
                 </p>
               </dd>
             </dl>
@@ -1923,8 +1925,9 @@ enum RTCStatsType {
               <dd>
                 <p>
                   If the {{RTCRtpTransceiver}} owning this stream has a
-                  {{RTCRtpTransceiver/mid}} value that is not null, this is that
-                  value, otherwise this member is [=map/exist | not present=].
+                  {{RTCRtpTransceiver/mid}} value that is not <code>null</code>,
+                  this is that value, otherwise this member MUST NOT be
+                  [= map/exist | present =].
                 </p>
               </dd>
               <dt>
@@ -2004,7 +2007,7 @@ enum RTCStatsType {
                 <p>
                   If RTX is negotiated for retransmissions on a separate <a>RTP stream</a>, this is the SSRC
                   of the RTX stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
-                  If RTX is not negotiated, this value is not present.
+                  If RTX is not negotiated, this value MUST NOT be [= map/exist | present =].
                 </p>
               </dd>
               <dt>
@@ -3383,7 +3386,7 @@ enum RTCStatsType {
                   {{RTCPeerConnectionIceEvent}}.
                 </p>
                 <p>
-                  For remote candidates, this property is not present.
+                  For remote candidates, this property is MUST NOT be [= map/exist | present =].
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Fixes #776


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/778.html" title="Last updated on Jan 12, 2024, 10:27 AM UTC (59b47d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/778/12c9dd3...henbos:59b47d4.html" title="Last updated on Jan 12, 2024, 10:27 AM UTC (59b47d4)">Diff</a>