### PR TITLE
clarify that sdpFmtpLine may not be there

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -879,7 +879,7 @@ enum RTCStatsType {
                   <code class="sdp">a=fmtp</code> line in the SDP
                   corresponding to the codec, if one [= map/exist =]s,
                   as defined by
-                  <span data-jsep="parsing-a-desc">[[!RFC8829]]</span>.
+                  [[!RFC8829]] (<a href="https://www.rfc-editor.org/rfc/rfc8829#section-5.8">section 5.8</a>).
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -875,8 +875,11 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The a=fmtp line in the SDP corresponding to the codec, i.e., after the colon
-                  following the PT. This defined by [[!JSEP]] in Section 5.7.
+                  The "format specific parameters" field from the
+                  <code class="sdp">a=fmtp</code> line in the SDP
+                  corresponding to the codec, if one [= map/exist =]s,
+                  as defined by
+                  <span data-jsep="parsing-a-desc">[[!RFC8829]]</span>.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -99,9 +99,6 @@ var respecConfig = {
             status:   "Internet Draft",
             publisher:  "IETF"
         },
-        "JSEP": {
-		"aliasOf": "RFC8829"
-        }
       },
   postProcess: [
     function generateStatsHierarchy(config, doc) {


### PR DESCRIPTION
fixes #779

oddly this does not render as `as defined by [RFC8829] (section 5.8.)` like the corresponding part in [webrtc-pc](https://w3c.github.io/webrtc-pc/#rtcrtpcodec) -- and as this shows getting the section numbers wrong is easy ;-)
It seems we need [linkToJsep magic](https://github.com/w3c/webrtc-pc/blob/main/webrtc.js#L105)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/780.html" title="Last updated on Jan 25, 2024, 3:24 PM UTC (df1c1ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/780/12c9dd3...fippo:df1c1ff.html" title="Last updated on Jan 25, 2024, 3:24 PM UTC (df1c1ff)">Diff</a>