### PR TITLE
sync local-candidate url definition with webrtc-pc

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3386,7 +3386,7 @@ enum RTCStatsType {
                 <p>
                   For local candidates of type {{RTCIceCandidateType/"srflx"}} or type
                   {{RTCIceCandidateType/"relay"}} this is the URL of the ICE server
-                  from which the candidate was obtained.
+                  from which the candidate was obtained and defined in [[WEBRTC]].
                 </p>
                 <p>
                   For remote candidates, this property is MUST NOT be [= map/exist | present =].
@@ -3400,6 +3400,9 @@ enum RTCStatsType {
                 <p>
                   It is the protocol used by the endpoint to communicate with the TURN server. This
                   is only present for local relay candidates and defined in [[WEBRTC]].
+                </p>
+                <p>
+                  For remote candidates, this property is MUST NOT be [= map/exist | present =].
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3402,7 +3402,7 @@ enum RTCStatsType {
                   is only present for local relay candidates and defined in [[WEBRTC]].
                 </p>
                 <p>
-                  For remote candidates, this property is MUST NOT be [= map/exist | present =].
+                  For remote candidates, this property MUST NOT be [= map/exist | present =].
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3389,7 +3389,7 @@ enum RTCStatsType {
                   from which the candidate was obtained and defined in [[WEBRTC]].
                 </p>
                 <p>
-                  For remote candidates, this property is MUST NOT be [= map/exist | present =].
+                  For remote candidates, this property MUST NOT be [= map/exist | present =].
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3384,9 +3384,9 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  For local candidates this is the URL of the ICE server from which the candidate
-                  was obtained. It is the same as the {{RTCPeerConnectionIceEvent/url}} surfaced in the
-                  {{RTCPeerConnectionIceEvent}}.
+                  For local candidates of type {{RTCIceCandidateType/"srflx"}} or type
+                  {{RTCIceCandidateType/"relay"}} this is the URL of the ICE server
+                  from which the candidate was obtained.
                 </p>
                 <p>
                   For remote candidates, this property is MUST NOT be [= map/exist | present =].


### PR DESCRIPTION
after https://github.com/w3c/webrtc-pc/pull/2773 decided to deprecate the url in the event.

(editorial)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/782.html" title="Last updated on Mar 7, 2024, 3:37 PM UTC (f936b3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/782/fdffc88...fippo:f936b3b.html" title="Last updated on Mar 7, 2024, 3:37 PM UTC (f936b3b)">Diff</a>