### PR TITLE
raddr+rport can be set for peer-reflexive candidates as well

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3456,8 +3456,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The ICE rel-addr defined in [[!RFC5245]] section 15.1. Only set for serverreflexive
-                  and relay candidates.
+                  The ICE rel-addr defined in [[!RFC5245]] section 15.1. Only set for serverreflexive,
+                  peerreflexive and relay candidates.
                 </p>
               </dd>
               <dt>
@@ -3465,8 +3465,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  The ICE rel-addr defined in [[!RFC5245]] section 15.1. Only set for serverreflexive
-                  and relay candidates.
+                  The ICE rel-addr defined in [[!RFC5245]] section 15.1. Only set for serverreflexive,
+                  peerreflexive and relay candidates.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
as described in RFC 5245 15.1
   If a candidate is server *or* peer reflexive,
   <rel-addr> and <rel-port> are equal to the base for that
   server or peer reflexive candidate


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/783.html" title="Last updated on Feb 24, 2024, 10:51 AM UTC (1f09e93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/783/a82fba9...fippo:1f09e93.html" title="Last updated on Feb 24, 2024, 10:51 AM UTC (1f09e93)">Diff</a>