### PR TITLE
Add definitions of corruption detection measurements

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1793,6 +1793,11 @@ enum RTCStatsType {
                   measurements SHOULD be [= map/exist | present =].
                 </p>
                 <p class="note">
+                  Note that the corruption-detection header extension documented at
+                  http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection is experimental. The
+                  identifier and format may change once an IETF standard has been established.
+                </p>
+                <p class="note">
                   The user agent MAY produce corruption likelihood measurements using any method available.
                   That could be facilitated by e.g. the mentioned corruption detection header extension,
                   reference-less image analysis such as natural image statistics, ML-based classification,

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1793,26 +1793,25 @@ enum RTCStatsType {
                   measurements SHOULD be [= map/exist | present =].
                 </p>
                 <p class="note">
-                  Note that the corruption-detection header extension documented at
-                  http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection is experimental. The
-                  identifier and format may change once an IETF standard has been established.
-                </p>
-                <p class="note">
                   The user agent MAY produce corruption likelihood measurements using any method available.
                   That could be facilitated by e.g. the mentioned corruption detection header extension,
                   reference-less image analysis such as natural image statistics, ML-based classification,
-                  or anything else capable of producing an estimate.
-                </p>
-                <p class="note">
-                  Note that these values are estimates - not guarantess. Even if the estimate is 0.0 there
-                  could be corruptions present (i.e. it's a false negative) for instance if random sampling
-                  is used and only a very small area of the frame is affected. Similarly, even if the estimate
-                  is 1.0 there might not be corruptions present (i.e. it's a false positive) for instance if
-                  the distribution of per-macroblock quantization parameters is extremely wide.
-
+                  or anything else capable of producing an estimate.<br>
+                  <br>
+                  The corruption likeliehood values are estimates - not guarantess. Even if the estimate is
+                  0.0 there could be corruptions present (i.e. it's a false negative) for instance if random
+                  sampling is used and only a very small area of the frame is affected. Similarly, even if the
+                  estimate is 1.0 there might not be corruptions present (i.e. it's a false positive) for
+                  instance if an image recognition technique is used while presenting a screenshot of a
+                  video encoding corruption.<br>
                   Just like there are edge cases for e.g. PSNR measrumenets, these metrics should primarily
                   be used as a basis for statistical analysis rather than be used as an absolute truth on a
-                  per-frame basis.
+                  per-frame basis.<br>
+                  <br>
+                  The corruption-detection header extension documented at
+                  <a href="http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection">
+                  http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection</a> is experimental. The
+                  identifier and format may change once an IETF standard has been established.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1004,6 +1004,9 @@ enum RTCStatsType {
              unsigned long long   retransmittedBytesReceived;
              unsigned long        rtxSsrc;
              unsigned long        fecSsrc;
+             double               totalCorruptionProbability;
+             double               totalSquaredCorruptionProbability;
+             unsigned long long   corruptionMeasurements;
             };</pre>
           <section>
             <h2>
@@ -1743,6 +1746,48 @@ enum RTCStatsType {
                   of the FEC stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
                   If FEC is not negotiated or uses the same <a>RTP stream</a>, this value MUST NOT be
                   [= map/exist | present =].
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalCorruptionProbability</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  MUST NOT [= map/exist =] for audio. Represents the cumulative sum of all corruption
+                  probability measurements that have been made for this SSRC, see {{corruptionMeasurements}}
+                  regarding when this attribute SHOULD be [= map/exist | present =].
+                </p>
+              </dd>
+              <dt>
+                <dfn>totalSquaredCorruptionProbability</dfn> of type <span class=
+                "idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  MUST NOT [= map/exist =] for audio. Represents the cumulative sum of all corruption
+                  probability measurements squared that have been made for this SSRC, see
+                  {{corruptionMeasurements}} regarding when this attribute SHOULD be [= map/exist | present =].
+                </p>
+              </dd>
+              <dt>
+                <dfn>corruptionMeasurements</dfn> of type <span class=
+                "idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  MUST NOT [= map/exist =] for audio. When the user agent is able to make a corruption
+                  probability measurement, this counter is incremented for each such measurement and
+                  {{totalCorruptionProbability}} and {{totalSquaredCorruptionProbability}} are aggregated
+                  with this measurement and measurement squared respectively.
+                </p>
+                <p>
+                  If the
+                  <a href="http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection">Corruption Detection</a>
+                  header extension has been negotatied, the user agent SHOULD produce measurements
+                  according to the algorithm in the header extension-explainer, but the user agent MAY produce
+                  measurements by other means, for example by reference-less image analysis compeletely on the
+                  receiver-side.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1766,6 +1766,16 @@ enum RTCStatsType {
                   likely some corruption visible, but it could for instance have a low magnitude or be present
                   only in a small portion of the frame.
                 </p>
+                <p class="note">
+                  The corruption likelihood values are estimates - not guarantees. Even if the estimate is
+                  0.0 there could be corruptions present (i.e. it's a false negative) for instance if only a
+                  very small area of the frame is affected. Similarly, even if the estimate is 1.0 there might
+                  not be a corruption present (i.e. it's a false positive) for instance if there are
+                  macroblocks with a QP far higher than the frame average.
+                  Just like there are edge cases for e.g. PSNR measurements, these metrics should primarily
+                  be used as a basis for statistical analysis rather than be used as an absolute truth on a
+                  per-frame basis.
+                </p>
               </dd>
               <dt>
                 <dfn>totalSquaredCorruptionProbability</dfn> of type <span class=
@@ -1789,25 +1799,10 @@ enum RTCStatsType {
                   {{totalCorruptionProbability}} and {{totalSquaredCorruptionProbability}} are aggregated
                   with this measurement and measurement squared respectively.
                   If the <a href="http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection">
-                  corruption-detection</a> header extension has been negotiated, corruptioned probability
-                  measurements SHOULD be [= map/exist | present =].
+                  corruption-detection</a> header extension is present in the RTP packets, corruption
+                  probability measurements MUST be [= map/exist | present =].
                 </p>
                 <p class="note">
-                  The user agent MAY produce corruption likelihood measurements using any method available.
-                  That could be facilitated by e.g. the mentioned corruption detection header extension,
-                  reference-less image analysis such as natural image statistics, ML-based classification,
-                  or anything else capable of producing an estimate.<br>
-                  <br>
-                  The corruption likeliehood values are estimates - not guarantess. Even if the estimate is
-                  0.0 there could be corruptions present (i.e. it's a false negative) for instance if random
-                  sampling is used and only a very small area of the frame is affected. Similarly, even if the
-                  estimate is 1.0 there might not be corruptions present (i.e. it's a false positive) for
-                  instance if an image recognition technique is used while presenting a screenshot of a
-                  video encoding corruption.<br>
-                  Just like there are edge cases for e.g. PSNR measrumenets, these metrics should primarily
-                  be used as a basis for statistical analysis rather than be used as an absolute truth on a
-                  per-frame basis.<br>
-                  <br>
                   The corruption-detection header extension documented at
                   <a href="http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection">
                   http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection</a> is experimental. The

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1758,6 +1758,14 @@ enum RTCStatsType {
                   probability measurements that have been made for this SSRC, see {{corruptionMeasurements}}
                   regarding when this attribute SHOULD be [= map/exist | present =].
                 </p>
+                <p>
+                  Each measurement added to {{totalCorruptionProbability}} MUST be in the range [0.0, 1.0],
+                  where a value of 0.0 indicates the system has estimated there is no or negligible corruption
+                  present in the processed frame. Similarly a value of 1.0 indicates there is almost certainly
+                  a corruption visible in the processed frame. A value in between those two indicates there is
+                  likely some corruption visible, but it could for instance have a low magnitude or be present
+                  only in a small portion of the frame.
+                </p>
               </dd>
               <dt>
                 <dfn>totalSquaredCorruptionProbability</dfn> of type <span class=
@@ -1780,15 +1788,26 @@ enum RTCStatsType {
                   probability measurement, this counter is incremented for each such measurement and
                   {{totalCorruptionProbability}} and {{totalSquaredCorruptionProbability}} are aggregated
                   with this measurement and measurement squared respectively.
+                  If the <a href="http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection">
+                  corruption-detection</a> header extension has been negotiated, corruptioned probability
+                  measurements SHOULD be [= map/exist | present =].
                 </p>
                 <p class="note">
-                  The user agent may produce corruption likelihood measurements using any method available.
-                  That could be facilitated by for instance: a side-channel for validation metadata such as
-                  the header extension described at
-                  <a href="http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection">
-                  http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection</a>, reference-less
-                  image analysis such as natural image statistics, ML-based classification, or anything else
-                  capable of producing an estimate.
+                  The user agent MAY produce corruption likelihood measurements using any method available.
+                  That could be facilitated by e.g. the mentioned corruption detection header extension,
+                  reference-less image analysis such as natural image statistics, ML-based classification,
+                  or anything else capable of producing an estimate.
+                </p>
+                <p class="note">
+                  Note that these values are estimates - not guarantess. Even if the estimate is 0.0 there
+                  could be corruptions present (i.e. it's a false negative) for instance if random sampling
+                  is used and only a very small area of the frame is affected. Similarly, even if the estimate
+                  is 1.0 there might not be corruptions present (i.e. it's a false positive) for instance if
+                  the distribution of per-macroblock quantization parameters is extremely wide.
+
+                  Just like there are edge cases for e.g. PSNR measrumenets, these metrics should primarily
+                  be used as a basis for statistical analysis rather than be used as an absolute truth on a
+                  per-frame basis.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1781,13 +1781,14 @@ enum RTCStatsType {
                   {{totalCorruptionProbability}} and {{totalSquaredCorruptionProbability}} are aggregated
                   with this measurement and measurement squared respectively.
                 </p>
-                <p>
-                  If the
-                  <a href="http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection">Corruption Detection</a>
-                  header extension has been negotatied, the user agent SHOULD produce measurements
-                  according to the algorithm in the header extension-explainer, but the user agent MAY produce
-                  measurements by other means, for example by reference-less image analysis compeletely on the
-                  receiver-side.
+                <p class="note">
+                  The user agent may produce corruption likelihood measurements using any method available.
+                  That could be facilitated by for instance: a side-channel for validation metadata such as
+                  the header extension described at
+                  <a href="http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection">
+                  http://www.webrtc.org/experiments/rtp-hdrext/corruption-detection</a>, reference-less
+                  image analysis such as natural image statistics, ML-based classification, or anything else
+                  capable of producing an estimate.
                 </p>
               </dd>
             </dl>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1768,7 +1768,7 @@ enum RTCStatsType {
                 </p>
                 <p class="note">
                   The corruption likelihood values are estimates - not guarantees. Even if the estimate is
-                  0.0 there could be corruptions present (i.e. it's a false negative) for instance if only a
+                  0.0, there could be corruptions present (i.e. it's a false negative) for instance if only a
                   very small area of the frame is affected. Similarly, even if the estimate is 1.0 there might
                   not be a corruption present (i.e. it's a false positive) for instance if there are
                   macroblocks with a QP far higher than the frame average.


### PR DESCRIPTION
Fixes #787

This PR adds new statistics for a corruption probability measure of a received video stream.

We include both the sum and sum of squares for this measure, so that a variance can be calculated.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sprangerik/webrtc-stats/pull/788.html" title="Last updated on Oct 29, 2024, 1:35 PM UTC (55c3100)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/788/d6c2dbf...sprangerik:55c3100.html" title="Last updated on Oct 29, 2024, 1:35 PM UTC (55c3100)">Diff</a>