### PR TITLE
Add counters that support deployment of L4S

### DIFF
--- a/l4s-explainer.md
+++ b/l4s-explainer.md
@@ -31,7 +31,7 @@ There are a number of scenarios we want to diagnose:
 *   Network drops: Packets marked with ECT(1) get dropped, packets without it get through
 *   CE-less chokepoints: We observe packet loss, but no CE markings.
 
-We may also want to look at packet loss vs packet reordering - when packets are lost, the reports will contain loss markings; when packets are reordered, later reports will overlap the previous reports and add info on packets previously lost.
+We may also want to look at packet loss vs packet reordering - when packets are lost, the reports will contain loss markings; when packets are reordered, later reports will overlap the previous reports and add info on packets previously reported as missing.
 
 
 ## Suggested counters and where to attach them
@@ -70,9 +70,9 @@ Diagnosing is performed at the sending endpoint.
 
 
 
-*   CE-aware chokepoints: ECT(1) is sent, ECT(1) and CE are in reports, reported ECT(1) + CE + lost add up to number of sent  packets (modulo in-flight). Bleaching stays at zero.
+*   CE-aware chokepoints: ECT(1) is sent, ECT(1) and CE are in reports, reported ECT(1) + CE + lost add up to the number of sent packets (modulo in-flight). Bleaching stays at zero.
 *   Bleaching: ECT(1) is sent, but “no marking” is reported. Number of sent packets and number of received packets + lost are roughly equal.
 *   Network drops: Packets sent with normal and ECT(1) are both above zero, but packets received are only normal, not ECT(1), and correspond to the number of normal packets. (NOTE: This is a failure scenario for deploying L4S)
-*   CE-less chokepoints: ECT(1) is sent and received, but CE counter remains at zero.
+*   CE-less chokepoints: ECT(1) is sent and received, but CE counter remains at zero. Number of packets reported as lost in RFC8888 reports is above zero.
 
 If excessive reordering occurs, the “reported later” counters will go up; the precise interpretation of that number depends on the strategy used for scheduling RFC8888 reports (longer intervals will allow more reordered packets to be recovered without this being visible in the reports).

--- a/l4s-explainer.md
+++ b/l4s-explainer.md
@@ -63,6 +63,13 @@ Attached to RTCRemoteInboundRtpStreamStats (which is a subclass of RTCReceivedRt
 
 Data in RTCRemoteInboundRtpStreamStats are computed based on a sender’s knowledge of the outgoing packets + data from remote reports (RR or RFC8888 reports). Computing “bleached” packets requires having both info on the sent packet and info on the RFC8888 report available.
 
+Attached to RTCTransportStats:
+
+* Number of RFC 8888 format feedback messages sent
+* Number of RFC 8888 format feedback messages received
+
+These numbers will allow monitoring of the frequency of RFC 8888 reporting.
+
 
 ## How to diagnose scenarios from these numbers
 

--- a/l4s-explainer.md
+++ b/l4s-explainer.md
@@ -6,9 +6,6 @@
 
 This explainer gives the background for the proposal to add stats to webrtc-stats to support the deployment of L4S and its prerequisite reporting format, RFC8888.
 
-(Google-only note: see go/webrtc-l4s for details on what L4S is and why it’s important).
-
-
 ## What is L4S
 
 L4S is a strategy for packet scheduling and marking in the Internet that is intended to make the Internet better for latency-sensitive applications that are capable of and willing to rapidly respond to signals that indicate queue buildup.

--- a/l4s-explainer.md
+++ b/l4s-explainer.md
@@ -1,0 +1,81 @@
+<!-- Output copied to clipboard! -->
+
+
+
+# Explainer - RFC8888 and L4S stats support in webrtc-stats
+
+This explainer gives the background for the proposal to add stats to webrtc-stats to support the deployment of L4S and its prerequisite reporting format, RFC8888.
+
+(Google-only note: see go/webrtc-l4s for details on what L4S is and why it’s important).
+
+
+## What is L4S
+
+L4S is a strategy for packet scheduling and marking in the Internet that is intended to make the Internet better for latency-sensitive applications that are capable of and willing to rapidly respond to signals that indicate queue buildup.
+
+The elements constituting L4S, seen from an application, are:
+
+
+
+*   The data sender marks outgoing packets with the bit pattern ECT(1) (01) (rather than the default, “no signal” (00)
+*   Network elements, when observing queue buildup, change the ECT(1) bit pattern to the CE (Congestion Experienced) bit pattern (11).
+*   The data recipient reflects the bits observed on each packet back to the sender, using the RFC8888 reporting format
+*   The data sender adjusts its send rate according to the observations in the report 
+
+
+## What we need to diagnose
+
+There are a number of scenarios we want to diagnose:
+
+
+
+*   CE-aware chokepoints: ECT(1) gets sent and received, the occasional CE gets received, and reflected back to the sender, which adjusts bitrate accordingly
+*   Bleaching: ECT(1) gets sent, but the recipient sees “No signal”
+*   Network drops: Packets marked with ECT(1) get dropped, packets without it get through
+*   CE-less chokepoints: We observe packet loss, but no CE markings.
+
+We may also want to look at packet loss vs packet reordering - when packets are lost, the reports will contain loss markings; when packets are reordered, later reports will overlap the previous reports and add info on packets previously lost.
+
+
+## Suggested counters and where to attach them
+
+The following counters are proposed:
+
+Attached to RTCSentRtpStreamStats:
+
+
+
+*   Number of packets sent with normal markings (this can be calculated from PacketsSent - Ect1PacketsSent, so no explicit counter is needed)
+*   Number of packets sent with ECT(1) markings
+
+Attached to RTCReceivedRtpStreamStats:
+
+
+
+*   Number of packets received with normal markings
+*   Number of packets received with ECT(1) marking
+*   Number of packets received with CE marking
+*   Number of packets reported as lost in RFC8888 reports
+*   Number of packets reported as lost in one RFC8888 report but later reported as arrived
+
+Attached to RTCRemoteInboundRtpStreamStats (which is a subclass of RTCReceivedRtpStreamStats):
+
+
+
+*   Number of packets sent with ECT(1) but reported as “no marking” (Bleached)
+
+Data in RTCRemoteInboundRtpStreamStats are computed based on a sender’s knowledge of the outgoing packets + data from remote reports (RR or RFC8888 reports). Computing “bleached” packets requires having both info on the sent packet and info on the RFC8888 report available.
+
+
+## How to diagnose scenarios from these numbers
+
+Diagnosing is performed at the sending endpoint.
+
+
+
+*   CE-aware chokepoints: ECT(1) is sent, ECT(1) and CE are in reports, reported ECT(1) + CE + lost add up to number of sent  packets (modulo in-flight). Bleaching stays at zero.
+*   Bleaching: ECT(1) is sent, but “no marking” is reported. Number of sent packets and number of received packets + lost are roughly equal.
+*   Network drops: Packets sent with normal and ECT(1) are both above zero, but packets received are only normal, not ECT(1), and correspond to the number of normal packets. (NOTE: This is a failure scenario for deploying L4S)
+*   CE-less chokepoints: ECT(1) is sent and received, but CE counter remains at zero.
+
+If excessive reordering occurs, the “reported later” counters will go up; the precise interpretation of that number depends on the strategy used for scheduling RFC8888 reports (longer intervals will allow more reordered packets to be recovered without this being visible in the reports).

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -947,7 +947,7 @@ enum RTCStatsType {
                   Only reported if support for the "ccfb" feedback mechanism has been negotiated.
                 </p>
               </dd>
-                <dfn>packetsReportedAsLostButRecovered</dfn> of type <span class="idlMemberType">unsigned long long</span>
+                <dt><dfn>packetsReportedAsLostButRecovered</dfn> of type <span class="idlMemberType">unsigned long long</span></dt>
               </dt>
               <dd>
                 <p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -893,6 +893,10 @@ enum RTCStatsType {
         <div>
           <pre class="idl">dictionary RTCReceivedRtpStreamStats : RTCRtpStreamStats {
              unsigned long long   packetsReceived;
+             unsigned long long   packetsReceivedWithEct1;
+             unsigned long long   packetsReceivedWithCe;
+             unsigned long long   packetsReportedAsLost;
+             unsigned long long   packetsReportedAsLostButRecovered;
              long long            packetsLost;
              double               jitter;
 };</pre>
@@ -915,6 +919,41 @@ enum RTCStatsType {
                   Report</a>, and then subtracting the initial Extended Sequence Number that was sent to this SSRC in a
                   <a>RTCP Sender Report</a> and then adding one, to mirror what is discussed in Appendix A.3 in [[!RFC3550]], but for the
                   sender side. If no <a>RTCP Receiver Report</a> has been received yet, then return 0.
+                </p>
+              </dd>
+              <dt>
+                <dfn>packetsReceivedWithEct1</dfn> of type <span class="idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  Total number of RTP packets received for this <a>SSRC</a> marked with the "ECT(1)" marking.
+                </p>
+              </dd>
+              <dt>
+                <dfn>packetsReceivedWithCe</dfn> of type <span class="idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  Total number of RTP packets received for this <a>SSRC</a> marked with the "CE" marking.
+                </p>
+              </dd>
+              <dt>
+              <dt>
+                <dfn>packetsReportedAsLost</dfn> of type <span class="idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  Total number of RTP packets for which an [[RFC8888]] section 3.1 report has been sent with a zero R bit.
+                  Only reported if support for the "ccfb" feedback mechanism has been negotiated.
+                </p>
+              </dd>
+                <dfn>packetsReportedAsLostButRecovered</dfn> of type <span class="idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  Total number of RTP packets for which an [[RFC8888]] section 3.1 report has been sent with a zero R bit,
+                  but a later report for the same packet has the R bit set to 1.
+                  Only reported if support for the "ccfb" feedback mechanism has been negotiated.
                 </p>
               </dd>
               <dt>
@@ -1830,6 +1869,7 @@ enum RTCStatsType {
              double               totalRoundTripTime;
              double               fractionLost;
              unsigned long long   roundTripTimeMeasurements;
+             unsigned long long   packetsWithBleachedEct1Marking;
 };</pre>
           <section>
             <h2>
@@ -1894,6 +1934,14 @@ enum RTCStatsType {
                   be calculated because no <a>RTCP Receiver Report</a> with a DLSR value other than 0 has been received.
                 </p>
               </dd>
+              <dt>
+                <dfn>packetsWithBleachedEct1Marking</dfn> of type <span class="idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                <p>
+                  Number of packets that were sent with ECT(1) markings per [[RFC3168]] section 3, but where an
+                  [[RFC8888]] report gave information that the packet was received with a marking of "not-ECT".
+                </p>
             </dl>
           </section>
         </div>
@@ -1904,8 +1952,9 @@ enum RTCStatsType {
         </h3>
         <div>
           <pre class="idl">dictionary RTCSentRtpStreamStats : RTCRtpStreamStats {
-             unsigned long long packetsSent;
-             unsigned long long bytesSent;
+            unsigned long long packetsSent;
+            unsigned long long bytesSent;
+            unsigned long long packetsSentWithEct1;
 };</pre>
           <section>
             <h2>
@@ -1932,6 +1981,13 @@ enum RTCStatsType {
                   Total number of bytes sent for this <a>SSRC</a>. This includes retransmissions.
                   Calculated as defined in [[!RFC3550]] section 6.4.1.
                 </p>
+              </dd>
+              <dt>
+                <dfn>packetsSentWithEct1</dfn> of type <span class="idlMemberType">unsigned long long</span>
+              </dt>
+              <dd>
+                Total number of RTP packets sent for this <a>SSRC</a> with the ECT(1) marking defined in [[RFC3168]]
+                section 5 and used by the L4S protocol described in [[RFC9331]].
               </dd>
             </dl>
           </section>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3170,6 +3170,8 @@ enum RTCStatsType {
              RTCDtlsRole           dtlsRole;
              DOMString             srtpCipher;
              unsigned long         selectedCandidatePairChanges;
+             unsigned long         ccfbMessagesSent;
+	     unsigned long         ccfbMessagesReceived;
 };</pre>
           <section>
             <h2>
@@ -3346,6 +3348,20 @@ enum RTCStatsType {
                   pair is selected.
                 </p>
               </dd>
+	      <dt>
+		      <dfn>ccfbMessagesSent</dfn> of type <span class="idlMemberType">unsigned long</span>span>
+	      </dt>
+	      <dd>
+		<p>The number of Transport-Layer Feedback Messages of type CongestionControl Feedback Packet, as described
+		in [[!RFC8888]] section 3.1, sent on this transport.</p>
+	      </dd>
+	      <dt>
+		      <dfn>ccfbMessagesReceived</dfn> of type <span class="idlMemberType">unsigned long</span>span>
+	      </dt>
+	      <dd>
+		<p>The number of Transport-Layer Feedback Messages of type CongestionControl Feedback Packet, as described
+		in [[!RFC8888]] section 3.1, received on this transport.</p>
+	      </dd>
             </dl>
           </section>
           <section>


### PR DESCRIPTION
These counters also depend on RFC8888 being deployed.

An explainer for the design is included.

Fixes #793


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/pull/792.html" title="Last updated on Mar 24, 2025, 7:31 PM UTC (e820135)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/792/02094bc...e820135.html" title="Last updated on Mar 24, 2025, 7:31 PM UTC (e820135)">Diff</a>