### PR TITLE
Add PSNR (Y/U/V) for outbound-rtp

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2247,11 +2247,11 @@ enum RTCStatsType {
                 </p>
                 <p>
                   The PSNR is defined in [[ISO-29170-1:2017]].
+                  The frequency of PSNR measurements is [=implementation-defined=].
                 </p>
                 <p class="note">
 		  PSNR metrics should primarily be used as a basis for statistical analysis rather
 		  than be used as an absolute truth on a per-frame basis.
-                  The frequency of PSNR measurements is [=implementation-defined=].
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2232,7 +2232,7 @@ enum RTCStatsType {
                   The count of measurements is in {{psnrMeasurements}}.
                 </p>
                 <p>
-                  PSNR is defined in [[!iso-29170-1:2017]].
+                  PSNR is defined in [[ISO-29170-1:2017]].
                 </p>
               </dd>
               <dt>
@@ -2246,7 +2246,7 @@ enum RTCStatsType {
                   aggregated with this measurement.
                 </p>
                 <p>
-                  The PSNR is defined in [[!iso-29170-1:2017]].
+                  The PSNR is defined in [[ISO-29170-1:2017]].
                 </p>
                 <p class="note">
                   The frequency of PSNR measurements is outside the scope of this specification.

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2259,6 +2259,11 @@ enum RTCStatsType {
                   The PSNR is defined in [[ISO-29170-1:2017]].
                   The frequency of PSNR measurements is [=implementation-defined=].
                 </p>
+                <p class="note">
+                  User agents are encouraged to measure PSNR at a fixed frequency
+                  for each encoder implementation, and as frequently as possible as
+                  long as it does not introduce a noticeable performance penalty.
+                </p>
               </dd>
               <dt>
                 <dfn>totalEncodeTime</dfn> of type <span class=

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2225,6 +2225,9 @@ enum RTCStatsType {
                 record&lt;DOMString, double&gt;</span>
               </dt>
               <dd>
+                <p class="fingerprint">
+                  MUST NOT [= map/exist =] unless [= exposing hardware is allowed =].
+                </p>
                 <p>
                   MUST NOT [= map/exist =] for audio.
                   The cumulative sum of the PSNR values of frames encoded by this sender.
@@ -2244,6 +2247,9 @@ enum RTCStatsType {
                 </span>
               </dt>
               <dd>
+                <p class="fingerprint">
+                  MUST NOT [= map/exist =] unless [= exposing hardware is allowed =].
+                </p>
                 <p>
                   MUST NOT [= map/exist =] for audio.
                   The number of times PSNR was measured. The components of {{psnrSum}} are

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2249,7 +2249,9 @@ enum RTCStatsType {
                   The PSNR is defined in [[ISO-29170-1:2017]].
                 </p>
                 <p class="note">
-                  The frequency of PSNR measurements is outside the scope of this specification.
+		  PSNR metrics should primarily be used as a basis for statistical analysis rather
+		  than be used as an absolute truth on a per-frame basis.
+                  The frequency of PSNR measurements is [=implementation-defined=].
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1966,6 +1966,10 @@ enum RTCStatsType {
              unsigned long        framesEncoded;
              unsigned long        keyFramesEncoded;
              unsigned long long   qpSum;
+             double               psnrSumY;
+             double               psnrSumU;
+             double               psnrSumV;
+             unsigned long long   psnrMeasurements;
              double               totalEncodeTime;
              double               totalPacketSendDelay;
              RTCQualityLimitationReason                 qualityLimitationReason;
@@ -2216,6 +2220,37 @@ enum RTCStatsType {
                 <p>
                   Note that the QP value is only an indication of quantizer values used; many
                   formats have ways to vary the quantizer value within the frame.
+                </p>
+              </dd>
+              <dt>
+                <dfn>psnrSumY</dfn>, <dfn>psnrSumU</dfn>, <dfn>psnrSumV</dfn> of type
+                <span class="idlMemberType">double</span>
+              </dt>
+              <dd>
+                <p>
+                  MUST NOT [= map/exist =] for audio.
+                  The cumulative sum of the PSNR values of frames encoded by this sender, for Y/U/V components.
+                  The count of measurements is in {{psnrMeasurements}}.
+                </p>
+                <p>
+                  PSNR is defined in [[!iso-29170-1:2017]].
+                </p>
+              </dd>
+              <dt>
+                <dfn>psnrMeasurements</dfn> of type <span class="idlMemberType">unsigned long long
+                </span>
+              </dt>
+              <dd>
+                <p>
+                  MUST NOT [= map/exist =] for audio.
+                  The number of times PSNR was measured. {{psnrSumY}}, {{psnrSumU}} and {{psnrSumV}} are
+                  aggregated with this measurement.
+                </p>
+                <p>
+                  The PSNR is defined in [[!iso-29170-1:2017]].
+                </p>
+                <p class="note">
+                  The frequency of PSNR measurements is outside the scope of this specification.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2235,8 +2235,8 @@ enum RTCStatsType {
                   PSNR is defined in [[ISO-29170-1:2017]].
                 </p>
                 <p class="note">
-		  PSNR metrics should primarily be used as a basis for statistical analysis rather
-		  than be used as an absolute truth on a per-frame basis.
+		  PSNR metrics are intended for statistical analysis rather
+		  than representing absolute truth on a per-frame basis.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1966,9 +1966,7 @@ enum RTCStatsType {
              unsigned long        framesEncoded;
              unsigned long        keyFramesEncoded;
              unsigned long long   qpSum;
-             double               psnrSumY;
-             double               psnrSumU;
-             double               psnrSumV;
+             record&lt;DOMString, double&gt; psnrSum;
              unsigned long long   psnrMeasurements;
              double               totalEncodeTime;
              double               totalPacketSendDelay;
@@ -2223,13 +2221,14 @@ enum RTCStatsType {
                 </p>
               </dd>
               <dt>
-                <dfn>psnrSumY</dfn>, <dfn>psnrSumU</dfn>, <dfn>psnrSumV</dfn> of type
-                <span class="idlMemberType">double</span>
+                <dfn>psnrSum</dfn> of type <span class="idlMemberType">
+                record&lt;DOMString, double&gt;</span>
               </dt>
               <dd>
                 <p>
                   MUST NOT [= map/exist =] for audio.
-                  The cumulative sum of the PSNR values of frames encoded by this sender, for Y/U/V components.
+                  The cumulative sum of the PSNR values of frames encoded by this sender.
+                  The record includes values for the "y", "u" and "v" components.
                   The count of measurements is in {{psnrMeasurements}}.
                 </p>
                 <p>
@@ -2243,7 +2242,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   MUST NOT [= map/exist =] for audio.
-                  The number of times PSNR was measured. {{psnrSumY}}, {{psnrSumU}} and {{psnrSumV}} are
+                  The number of times PSNR was measured. The components of {{psnrSum}} are
                   aggregated with this measurement.
                 </p>
                 <p>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2234,6 +2234,10 @@ enum RTCStatsType {
                 <p>
                   PSNR is defined in [[ISO-29170-1:2017]].
                 </p>
+                <p class="note">
+		  PSNR metrics should primarily be used as a basis for statistical analysis rather
+		  than be used as an absolute truth on a per-frame basis.
+                </p>
               </dd>
               <dt>
                 <dfn>psnrMeasurements</dfn> of type <span class="idlMemberType">unsigned long long
@@ -2248,10 +2252,6 @@ enum RTCStatsType {
                 <p>
                   The PSNR is defined in [[ISO-29170-1:2017]].
                   The frequency of PSNR measurements is [=implementation-defined=].
-                </p>
-                <p class="note">
-		  PSNR metrics should primarily be used as a basis for statistical analysis rather
-		  than be used as an absolute truth on a per-frame basis.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -99,6 +99,11 @@ var respecConfig = {
             status:   "Internet Draft",
             publisher:  "IETF"
         },
+	"iso-29170-1:2017": {
+	  title: "Information technology — Advanced image coding and evaluation",
+	  href: "https://www.iso.org/standard/63637.html",
+	  publisher: "ISO",
+	},
       },
   postProcess: [
     function generateStatsHierarchy(config, doc) {

--- a/webrtc-stats.js
+++ b/webrtc-stats.js
@@ -99,7 +99,7 @@ var respecConfig = {
             status:   "Internet Draft",
             publisher:  "IETF"
         },
-	"iso-29170-1:2017": {
+	"ISO-29170-1:2017": {
 	  title: "Information technology — Advanced image coding and evaluation",
 	  href: "https://www.iso.org/standard/63637.html",
 	  publisher: "ISO",


### PR DESCRIPTION
This is similar to qpSum but codec-independent.

Since PSNR requires additional computation it is defined with an
accompanying psnrMeasurements counter to allow the computation of
an average PSNR.

Defined as a record with components for the Y, U and V planes respectively.

See also
  https://datatracker.ietf.org/doc/html/rfc8761#section-5


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/794.html" title="Last updated on Jul 10, 2025, 2:41 PM UTC (18f34e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/794/02094bc...fippo:18f34e5.html" title="Last updated on Jul 10, 2025, 2:41 PM UTC (18f34e5)">Diff</a>