### PR TITLE
fix typo: simulast

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -639,7 +639,7 @@ enum RTCStatsType {
         </p>
         <p>
           For a given RTP stats object, its total counters must always increase,
-          but due to changes in SSRC, simulast layers dropping or transceivers
+          but due to changes in SSRC, simulcast layers dropping or transceivers
           stopping, an RTP stats object can be deleted and/or replaced by a new
           RTP stats object. The caller will need to be aware of this when aggregating
           packet counters accross multiple RTP stats objects (the aggregates may


### PR DESCRIPTION
(I would not agree with "simulcast layer is dropped for BW reasons, stats go away) but that is orthogonal to the typo


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/798.html" title="Last updated on Mar 1, 2025, 4:30 AM UTC (cc81fc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/798/71dbce9...fippo:cc81fc7.html" title="Last updated on Mar 1, 2025, 4:30 AM UTC (cc81fc7)">Diff</a>