### PR TITLE
Update RTP lifetime description: outbound-rtp to be created before first packet is sent

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -620,9 +620,12 @@ enum RTCStatsType {
           RTCP SR or RR block.
         </p>
         <p>
-          The lifetime of all RTP [= monitored object =]s starts when the <a>RTP stream</a> is first
-          used: When the first RTP packet is sent or received on the <a>SSRC</a> it represents, or when
-          the first RTCP packet is sent or received that refers to the <a>SSRC</a> of the <a>RTP stream</a>.
+          The lifetime of all RTP [= monitored object =]s are tied to <a>SSRC</a>s.
+          The {{RTCOutboundRtpStreamStats}} is created when the RTP sender is configured by
+          <code>setLocalDescription()</code>, the {{RTCInboundRtpStreamStats}} is created when
+          the first RTP packet for this SSRC is received and the remote RTP stream stats
+          objects ({{RTCRemoteInboundRtpStreamStats}} and {{RTCRemoteOutboundRtpStreamStats}})
+          are created when the corresponding RTCP packet is first received.
         </p>
         <p>
           RTP monitored objects are deleted when the corresponding RTP sender or

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -622,7 +622,9 @@ enum RTCStatsType {
         <p>
           The lifetime of all RTP [= monitored object =]s are tied to <a>SSRC</a>s.
           The {{RTCOutboundRtpStreamStats}} is created when the RTP sender is configured by
-          <code>setLocalDescription()</code>, the {{RTCInboundRtpStreamStats}} is created when
+          setting a local or remote SDP answer (via <code>setLocalDescription()</code>
+          or <code>setRemoteDescription()</code> and the signaling state returning to
+          <code>"stable"</code>). The {{RTCInboundRtpStreamStats}} is created when
           the first RTP packet for this SSRC is received and the remote RTP stream stats
           objects ({{RTCRemoteInboundRtpStreamStats}} and {{RTCRemoteOutboundRtpStreamStats}})
           are created when the corresponding RTCP packet is first received.


### PR DESCRIPTION
Fixes #797.

[Original description] The RTP sender is created at setLocalDescription time, i.e. has-local-offer or stable. This is consistent with the transceiver's MID value also being assigned at this point in time.
- I have verified that this description is consistent with Chrome Stable: [offerer fiddle](https://jsfiddle.net/gy8us4Lk/) and [answerer fiddle](https://jsfiddle.net/5ytoqzum/).

[Update based on review] The RTP sender is configured when we go back to stable signaling state (SDP answer is set), this means both Chrome and Firefox needs to update its behavior

WPT test coverage is being added [here](https://chromium-review.googlesource.com/c/chromium/src/+/6402253).
- Chrome currently passes the first test and fails the second but I'm happy to make Chrome pass both tests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/802.html" title="Last updated on Mar 28, 2025, 9:39 AM UTC (ebb579a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/802/d3baab4...henbos:ebb579a.html" title="Last updated on Mar 28, 2025, 9:39 AM UTC (ebb579a)">Diff</a>