### PR TITLE
Add outbound-rtp.encodingIndex.

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -2098,14 +2098,9 @@ enum RTCStatsType {
               <dd>
                 <p>
                   MUST NOT [= map/exist =] for audio.
-                  Only [= map/exist =]s if this <a>RTP stream</a> belongs to an
-                  RTP sender that has been configured for simulcast, in other
-                  words the {{RTCRtpSender}} has multiple
-                  {{RTCRtpSendParameters/encodings}} and
-                  {{RTCOutboundRtpStreamStats}} objects. The {{encodingIndex}}
-                  is the index of the encoding that represents this <a>RTP
-                  stream</a>. MUST NOT be [= map/exist | present =] for
-                  singlecast senders.
+                  This is the index of the encoding that represents this
+                  <a>RTP stream</a> in the RTP sender's list of
+                  {{RTCRtpSendParameters/encodings}}.
                 </p>
               </dd>
               <dt>

--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1952,6 +1952,7 @@ enum RTCStatsType {
              DOMString            mediaSourceId;
              DOMString            remoteId;
              DOMString            rid;
+             unsigned long        encodingIndex;
              unsigned long long   headerBytesSent;
              unsigned long long   retransmittedPacketsSent;
              unsigned long long   retransmittedBytesSent;
@@ -2027,6 +2028,23 @@ enum RTCStatsType {
                   has been set for this <a>RTP stream</a>.
                   If {{RTCRtpCodingParameters/rid}} is set this value will be present
                   regardless if the RID RTP header extension has been negotiated.
+                </p>
+              </dd>
+              <dt>
+                <dfn>encodingIndex</dfn> of type <span class="idlMemberType">
+                unsigned long</span>
+              </dt>
+              <dd>
+                <p>
+                  MUST NOT [= map/exist =] for audio.
+                  Only [= map/exist =]s if this <a>RTP stream</a> belongs to an
+                  RTP sender that has been configured for simulcast, in other
+                  words the {{RTCRtpSender}} has multiple
+                  {{RTCRtpSendParameters/encodings}} and
+                  {{RTCOutboundRtpStreamStats}} objects. The {{encodingIndex}}
+                  is the index of the encoding that represents this <a>RTP
+                  stream</a>. MUST NOT be [= map/exist | present =] for
+                  singlecast senders.
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Fixes #801.

Sorting requires it to be an index. Sorting or not, we need to know which encoding has which SSRC. and different streams may use different RIDs for different semantics, e.g. {q,h,f} = {quarter, half, full} may be used for camera streams and {l,h} = {lowFps, highFps} may be used for screenshare streams. Or something else, we don't want to have coupling between the stats pipeline and arbitrary app naming conventions somewhere else which are not set in stone or consistent.

The stats pipeline is typically a separate part of the code base or even an entirely external tool like https://fippo.github.io/webrtc-dump-importer/ which does not have access to JS APIs like getParameters().

The stats pipeline often executes after the call has ended, so index needs to be stored inside the report for later analysis. Why force the app to have to modify the RTCStatsReport even if it could do it?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-stats/pull/803.html" title="Last updated on Mar 28, 2025, 9:59 AM UTC (4a9229c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/803/62bad06...henbos:4a9229c.html" title="Last updated on Mar 28, 2025, 9:59 AM UTC (4a9229c)">Diff</a>