### PR TITLE
Make audioLevel [=implementation-defined=]

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -1599,8 +1599,7 @@ enum RTCStatsType {
                 </p>
                 <p>
                   The {{audioLevel}} is averaged over some small interval, using the algorithm
-                  described under {{totalAudioEnergy}}. The interval used is implementation
-                  dependent.
+                  described under {{totalAudioEnergy}}. The interval used is [=implementation-defined=].
                 </p>
               </dd>
               <dt>
@@ -2789,8 +2788,7 @@ enum RTCStatsType {
                 </p>
                 <p>
                   The {{audioLevel}} is averaged over some small interval, using the algorithm
-                  described under {{totalAudioEnergy}}. The interval used is implementation
-                  dependent.
+                  described under {{totalAudioEnergy}}. The interval used is [=implementation-defined=].
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
instead of the informal "implementation dependent"

@jan-ivar I look forward to your exegesis of the interval :-p