### PR TITLE
clarify data channels bytesSent/bytesReceived

### DIFF
--- a/webrtc-stats.html
+++ b/webrtc-stats.html
@@ -3179,7 +3179,7 @@ enum RTCStatsType {
               <dd>
                 <p>
                   Represents the total number of payload bytes sent on this
-                  {{RTCDataChannel}}, i.e., not including headers or padding.
+                  {{RTCDataChannel}}.
                 </p>
               </dd>
               <dt>
@@ -3197,8 +3197,8 @@ enum RTCStatsType {
               </dt>
               <dd>
                 <p>
-                  Represents the total number of bytes received on this
-                  {{RTCDataChannel}}, i.e., not including headers or padding.
+                  Represents the total number of payload bytes received on this
+                  {{RTCDataChannel}}.
                 </p>
               </dd>
             </dl>


### PR DESCRIPTION
and remove the mention of headers and padding which are not a thing for SCTP


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-stats/pull/811.html" title="Last updated on Aug 7, 2025, 3:42 PM UTC (7b69c6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-stats/811/efecbcd...fippo:7b69c6b.html" title="Last updated on Aug 7, 2025, 3:42 PM UTC (7b69c6b)">Diff</a>